### PR TITLE
Checking if Var Exists Before Evaluating

### DIFF
--- a/includes/wp-mail.php
+++ b/includes/wp-mail.php
@@ -139,8 +139,8 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 		'text' => $message
 	);
 
-	$body['o:tracking-clicks'] = $mailgun['track-clicks'] ? $mailgun['track-clicks'] : "no";
-	$body['o:tracking-opens'] = $mailgun['track-opens'] ? "yes" : "no";
+	$body['o:tracking-clicks'] = isset( $mailgun['track-clicks'] ) ? $mailgun['track-clicks'] : "no";
+	$body['o:tracking-opens'] = isset( $mailgun['track-opens'] ) ? "yes" : "no";
 
 	if ( isset( $mailgun['tag'] ) ){
 		$tags = explode(",", str_replace(" ","", $mailgun['tag']));
@@ -235,12 +235,12 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	        $i++;
 		}
 	}
-	
+
 	$payload .= '--' . $boundary . '--';
-	
+
 	$data = array(
 		'body' => $payload,
-		'headers' => array('Authorization' => 'Basic ' . base64_encode( "api:{$apiKey}"), 
+		'headers' => array('Authorization' => 'Basic ' . base64_encode( "api:{$apiKey}"),
 					       'content-type' => 'multipart/form-data; boundary=' . $boundary)
 	);
 


### PR DESCRIPTION
I get these notices when I try to send an email:

> Notice: Undefined index: track-clicks in /Users/patrick/Documents/web/projects/ninja-forms/wp-content/plugins/mailgun/includes/wp-mail.php on line 142
> 
> Notice: Undefined index: track-opens in /Users/patrick/Documents/web/projects/ninja-forms/wp-content/plugins/mailgun/includes/wp-mail.php on line 143

I checked to make sure the variable exists before evaluating them and that made them go away. :)
