### PR TITLE
Change incorrect host name

### DIFF
--- a/mailgun.php
+++ b/mailgun.php
@@ -69,7 +69,7 @@ class Mailgun {
 
 		$phpmailer->Mailer = 'smtp';
 		$phpmailer->SMTPSecure = (bool) $secure ? 'ssl' : 'none';
-		$phpmailer->Host = 'smtp.mailgun.net';
+		$phpmailer->Host = 'smtp.mailgun.org';
 		$phpmailer->Port = (bool) $secure ? 465 : 587;
 		$phpmailer->SMTPAuth = true;
 		$phpmailer->Username = $username;


### PR DESCRIPTION
Change incorrect host name from smtp.mailgun.net to smtp.mailgun.org
