### PR TITLE
check for track-opens changed from isset to empty

### DIFF
--- a/includes/wp-mail.php
+++ b/includes/wp-mail.php
@@ -140,7 +140,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	);
 
 	$body['o:tracking-clicks'] = isset( $mailgun['track-clicks'] ) ? $mailgun['track-clicks'] : "no";
-	$body['o:tracking-opens'] = isset( $mailgun['track-opens'] ) ? "yes" : "no";
+	$body['o:tracking-opens'] = empty( $mailgun['track-opens'] ) ? "no" : "yes";
 
 	if ( isset( $mailgun['tag'] ) ){
 		$tags = explode(",", str_replace(" ","", $mailgun['tag']));


### PR DESCRIPTION
The <select> drop down in the settings menu for mailgun has the values "0" and "1" to decide whether or not to track mail opens, however the wp_mail functions checks if isset($mailgun['track-opens']) which will return true for either scenario as 0 still counts as set. Switched to empty()
