### PR TITLE
Update to the latest version and bugfix

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -67,6 +67,7 @@ class MailgunAdmin extends Mailgun {
 	function admin_menu() {
 		if ( current_user_can( 'manage_options' ) ) {
 			$this->hook_suffix = add_options_page( __( 'Mailgun', 'mailgun' ), __( 'Mailgun', 'mailgun' ), 'manage_options', 'mailgun', array( &$this , 'options_page' ) );
+			add_options_page( __( 'Mailgun Lists', 'mailgun' ), null, 'manage_options', 'mailgun-lists', array( &$this , 'lists_page' ) );
 			add_action( "admin_print_scripts-{$this->hook_suffix}" , array( &$this , 'admin_js' ) );
 			add_filter( "plugin_action_links_{$this->plugin_basename}" , array( &$this , 'filter_plugin_actions' ) );
 			add_action( "admin_footer-{$this->hook_suffix}" , array( &$this , 'admin_footer_js' ) );
@@ -155,6 +156,20 @@ class MailgunAdmin extends Mailgun {
 			printf( __( '<div id="message" class="updated fade"><p>The options page for the <strong>Mailgun</strong> plugin cannot be displayed. The file <strong>%s</strong> is missing.  Please reinstall the plugin.</p></div>', 'mailgun'), dirname( __FILE__ ) . '/options-page.php' );
 		}
 	}
+	
+	/**
+	 * Output the lists page
+	 *
+	 * @return none
+	 * @since 0.1
+	 */
+	function lists_page() {
+		if ( ! @include( 'lists-page.php' ) ) {
+			printf( __( '<div id="message" class="updated fade"><p>The lists page for the <strong>Mailgun</strong> plugin cannot be displayed. The file <strong>%s</strong> is missing.  Please reinstall the plugin.</p></div>', 'mailgun'), dirname( __FILE__ ) . '/lists-page.php' );
+		}
+	}	
+	
+	// /options-general.php?page=mailgun-lists
 
 	/**
 	 * Wrapper function hooked into admin_init to register settings

--- a/includes/lists-page.php
+++ b/includes/lists-page.php
@@ -1,0 +1,76 @@
+<?php
+
+	global $mailgun;
+
+	// check mailgun domain & api key
+	$missing_error = '';
+	$api_key = $this->get_option( 'apiKey' );
+	$mailgun_domain = $this->get_option( 'domain' );
+	if($api_key != ''){
+		if($mailgun_domain == ''){
+			$missing_error = '<strong style="color:red;">Missing or invalid Mailgun Domain</strong>. ';
+		}
+	} else {
+		$missing_error = '<strong style="color:red;">Missing or invalid API Key</strong>. ';
+	}
+	
+	// import available lists
+	$lists_arr = $mailgun->get_lists();
+	
+?>
+
+<div class="wrap">
+
+	<div id="icon-options-general" class="icon32"><br /></div>
+
+	<span class="alignright">
+		<a target="_blank" href="http://www.mailgun.com/">
+			<img src="https://2e6874288eee3bf7ca22-d122329f808928cff1e9967578106854.ssl.cf1.rackcdn.com/mailgun-logo.png" alt="Mailgun" />
+		</a>
+	</span>
+
+	<h2><?php _e( 'Mailgun Lists' , 'mailgun' ); ?></h2>
+	
+	<?php settings_fields( 'mailgun' ); ?>
+
+	<h3><?php _e( 'Available Mailing Lists' , 'mailgun' ); ?> | <a href="/wp-admin/options-general.php?page=mailgun">Back to settings</a></h3>
+
+	<p><?php _e( "{$missing_error}You must use a valid Mailgun domain name and API key to access lists", 'mailgun' ); ?></p>
+	
+	<div id="mailgun-lists" style="margin-top:20px;">
+
+		<?php if( !empty($lists_arr) ) : ?>
+
+			<table class="wp-list-table widefat fixed striped pages">
+
+				<tr>
+					<th>List Address</th>
+					<th>Description</th>
+					<th>Shortcode</th>
+				</tr>
+
+				<?php foreach($lists_arr as $list) : ?>
+
+					<tr>
+						<td><?php echo $list['address']; ?></td>
+						<td><?php echo $list['description']; ?></td>
+						<td>
+							[mailgun id="<?php echo $list['address']; ?>"]
+						</td>
+					</tr>
+
+				<?php endforeach; ?>
+
+			</table>
+
+			<h3>Multi-list subscription</h3>
+			<p>
+				<?php _e( 'To allow users to subscribe to multiple lists on a single form, comma-separate the Mailgun list ids.', 'mailgun' ); ?></p>
+			<p class="description">
+				<?php _e( '<strong>Example:</strong> [mailgun id="list1@mydomain.com,list2@mydomain.com"]'); ?>
+			</p>
+
+		<?php endif; ?>
+
+	</div>
+</div>

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -95,23 +95,39 @@
 					</tr>
 					<tr valign="top">
 						<th scope="row">
-							<?php _e( 'Campaign ID' , 'mailgun' ); ?>
+							<?php _e( 'Tag' , 'mailgun' ); ?>
 						</th>
 						<td>
-							<input type="text" class="regular-text" name="mailgun[campaign-id]" value="<?php esc_attr_e( $this->get_option( 'campaign-id' ) ); ?>" placeholder="campaign-id" />
-							<p class="description"><?php _e( 'If added, this campaign will exist on every outbound message. Statistics will be populated in the Mailgun Control Panel. Use a comma to define multiple campaigns.', 'mailgun' ); ?>  <a href="http://documentation.mailgun.com/user_manual.html#campaign-analytics" target="_blank">Campaign Documentation</a></p>
+							<input type="text" class="regular-text" name="mailgun[campaign-id]" value="<?php esc_attr_e( $this->get_option( 'campaign-id' ) ); ?>" placeholder="tag" />
+							<p class="description"><?php _e( 'If added, this tag will exist on every outbound message. Statistics will be populated in the Mailgun Control Panel. Use a comma to define multiple tags.', 'mailgun' ); ?> <?php _e('Learn more about','mailgun'); ?> <a href="https://documentation.mailgun.com/user_manual.html#tracking-messages" target="_blank">Tracking</a> <?php _e('and','mailgun'); ?> <a href="https://documentation.mailgun.com/user_manual.html#tagging" target="_blank">Tagging</a>.</p>
+						</td>
+					</tr>
+				</table>
+				<h3><?php _e( 'Lists' , 'mailgun' ); ?></h3>
+				<table class="form-table">
+					<tr valign="top">
+						<th scope="row">
+							<?php _e( 'Shortcode' , 'mailgun' ); ?>
+						</th>
+						<td>
+							<div>
+								<strong>[mailgun id="<em>{mailgun list id}</em>" collect_name="true"]</strong>
+							</div>
+							<div>
+								<p class="description"><?php _e( 'Use the shortcode above to associate a widget instance with a mailgun list', 'mailgun' ); ?></p>
+							</div>
 						</td>
 					</tr>
 					<tr valign="top">
 						<th scope="row">
-							<?php _e( 'Tag' , 'mailgun' ); ?>
+							<?php _e( 'Lists' , 'mailgun' ); ?>
 						</th>
 						<td>
-							<input type="text" class="regular-text" name="mailgun[tag]" value="<?php esc_attr_e( $this->get_option( 'tag' ) ); ?>" placeholder="tag" />
-							<p class="description"><?php _e( 'If added, this tag will exist on every outbound message. Statistics will be populated in the Mailgun Control Panel. Use a comma to define multiple tags.', 'mailgun' ); ?> <a href="http://documentation.mailgun.com/user_manual.html#tagging" target="_blank">Tagging Documentation</a></p>
+							<a href="?page=mailgun-lists">View available lists</a>
 						</td>
 					</tr>
 				</table>
+
 				<p><?php _e( 'Before attempting to test the configuration, please click "Save Changes".', 'mailgun' ); ?></p>
 				<p class="submit">
 					<input type="submit" class="button-primary" value="<?php _e( 'Save Changes' , 'mailgun' ); ?>" />

--- a/includes/widget.php
+++ b/includes/widget.php
@@ -1,0 +1,93 @@
+<?php
+
+class list_widget extends WP_Widget {
+
+	function __construct() {
+		parent::__construct(
+			// Base ID of your widget
+			'list_widget',
+	
+			// Widget name will appear in UI
+			__('Mailgun List Widget', 'wpb_widget_domain'),
+	
+			// Widget description
+			array( 'description' => __( 'Mailgun list widget', 'wpb_widget_domain' ), )
+		);
+	}
+
+	// Creating widget front-end
+	// This is where the action happens
+	public function widget($args, $instance) {
+		global $mailgun;
+
+		// vars
+		$list_address = apply_filters('list_address', $instance['list_address']);
+
+		if( isset($instance['collect_name']) ) {
+			$args['collect_name'] = true;
+		}
+
+		if( isset($instance['list_title']) ) {
+			$args['list_title'] = $instance['list_title'];
+		}
+
+		if( isset($instance['list_description']) ) {
+			$args['list_description'] = $instance['list_description'];
+		}
+
+		$mailgun->list_form($list_address, $args, $instance);
+    }
+
+    // Widget Backend 
+    public function form( $instance ) {
+		global $mailgun;
+    	
+        if ( isset( $instance[ 'list_address' ] ) ) {
+            $list_address = $instance[ 'list_address' ];
+        } else {
+            $list_address = __( 'New list_address', 'wpb_widget_domain' );
+        }
+
+		if ( isset( $instance[ 'collect_name' ] ) && $instance[ 'collect_name' ] === 'on' ) {
+            $collect_name = 'checked';
+        } else {
+        	$collect_name = '';
+        }
+
+        $list_title = isset( $instance[ 'list_title' ] ) ? $instance['list_title'] : null;
+        $list_description = isset( $instance[ 'list_description' ] ) ? $instance['list_description'] : null;
+        
+        // Widget admin form
+        ?>
+        <div class="mailgun-list-widget-back">
+        	<p>
+	            <label for="<?php echo $this->get_field_id( 'list_title' ); ?>"><?php _e( 'Title (optional):' ); ?></label> 
+	            <input class="widefat" id="<?php echo $this->get_field_id( 'list_title' ); ?>" name="<?php echo $this->get_field_name( 'list_title' ); ?>" type="text" value="<?php echo esc_attr( $list_title ); ?>" />
+	        </p>
+	        <p>
+	            <label for="<?php echo $this->get_field_id( 'list_description' ); ?>"><?php _e( 'Description (optional):' ); ?></label> 
+	            <input class="widefat" id="<?php echo $this->get_field_id( 'list_description' ); ?>" name="<?php echo $this->get_field_name( 'list_description' ); ?>" type="text" value="<?php echo esc_attr( $list_description ); ?>" />
+	        </p>
+	        <p>
+	            <label for="<?php echo $this->get_field_id( 'list_address' ); ?>"><?php _e( 'List addresses (required):' ); ?></label> 
+	            <input class="widefat" id="<?php echo $this->get_field_id( 'list_address' ); ?>" name="<?php echo $this->get_field_name( 'list_address' ); ?>" type="text" value="<?php echo esc_attr( $list_address ); ?>" />
+	        </p>
+	        <p>
+	            <label for="<?php echo $this->get_field_id( 'collect_name' ); ?>"><?php _e( 'Collect name:' ); ?></label> 
+	            <input class="widefat" id="<?php echo $this->get_field_id( 'collect_name' ); ?>" name="<?php echo $this->get_field_name( 'collect_name' ); ?>" type="checkbox" <?php echo esc_attr( $collect_name ); ?> />
+	        </p>
+        </div>
+        <?php 
+    }
+    
+    // Updating widget replacing old instances with new
+    public function update( $new_instance, $old_instance ) {
+    	$instance = array();
+       	$instance = $new_instance; 
+
+        return $instance;
+    }
+}
+
+
+

--- a/includes/wp-mail.php
+++ b/includes/wp-mail.php
@@ -142,14 +142,20 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 	$body['o:tracking-clicks'] = isset( $mailgun['track-clicks'] ) ? $mailgun['track-clicks'] : "no";
 	$body['o:tracking-opens'] = isset( $mailgun['track-opens'] ) ? "yes" : "no";
 
+    // this is the wordpress site tag
 	if ( isset( $mailgun['tag'] ) ){
 		$tags = explode(",", str_replace(" ","", $mailgun['tag']));
 		$body['o:tag'] = $tags;
 	}
 
+    // campaign-id now refers to a list of tags which will be appended to the site tag
 	if ( isset( $mailgun['campaign-id'] ) ){
-		$campaigns = explode(",", str_replace(" ","", $mailgun['campaign-id']));
-		$body['o:campaign'] = $campaigns;
+		$tags = explode(",", str_replace(" ","", $mailgun['campaign-id']));
+		if ($body['o:tag']=='') {
+			$body['o:tag']= $tags;
+		} else {
+			$body['o:tag'].=','.$tags;
+		}
 	}
 
 	if ( ! empty( $cc ) && is_array( $cc ) )
@@ -209,7 +215,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 			foreach($value as $key => $value){
 				$payload .= '--' . $boundary;
 		        $payload .= "\r\n";
-		        $payload .= 'Content-Disposition: form-data; name="' . $parent_key . '[' . $key . ']"' . "\r\n\r\n";
+		        $payload .= 'Content-Disposition: form-data; name="' . $parent_key . "\"\r\n\r\n";
 		        $payload .= $value;
 		        $payload .= "\r\n";
 			}

--- a/includes/wp-mail.php
+++ b/includes/wp-mail.php
@@ -151,7 +151,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
     // campaign-id now refers to a list of tags which will be appended to the site tag
 	if ( isset( $mailgun['campaign-id'] ) ){
 		$tags = explode(",", str_replace(" ","", $mailgun['campaign-id']));
-		if ($body['o:tag']=='') {
+		if (!isset($body['o:tag'])) {
 			$body['o:tag']= $tags;
 		} else {
 			$body['o:tag'].=','.$tags;

--- a/mailgun.php
+++ b/mailgun.php
@@ -3,8 +3,8 @@
  * Plugin Name:  Mailgun
  * Plugin URI:   http://wordpress.org/extend/plugins/mailgun/
  * Description:  Mailgun integration for WordPress
- * Version:      1.0
- * Author:       Matt Martz
+ * Version:      1.4
+ * Author:       Mailgun
  * Author URI:   http://www.mailgun.com/
  * License:      GPLv2 or later
  * Text Domain:  mailgun
@@ -19,10 +19,11 @@ class Mailgun {
 	 * @return none
 	 * @since 0.1
 	 */
-	function __construct() {
+	public function __construct() {
 		$this->options = get_option( 'mailgun' );
 		$this->plugin_file = __FILE__;
 		$this->plugin_basename = plugin_basename( $this->plugin_file );
+		$this->api_endpoint = 'https://api.mailgun.net/v3/';
 
 		// Either override the wp_mail function or configure PHPMailer to use the
 		// Mailgun SMTP servers
@@ -43,7 +44,7 @@ class Mailgun {
 	 * @return mixed
 	 * @since 0.1
 	 */
-	function get_option( $option, $options = null ) {
+	public function get_option( $option, $options = null ) {
 		if ( is_null( $options ) )
 			$options = &$this->options;
 		if ( isset( $options[$option] ) )
@@ -60,7 +61,7 @@ class Mailgun {
 	 * @return none
 	 * @since 0.1
 	 */
-	function phpmailer_init( &$phpmailer ) {
+	public function phpmailer_init( &$phpmailer ) {
 		$username = ( defined( 'MAILGUN_USERNAME' ) && MAILGUN_USERNAME ) ? MAILGUN_USERNAME : $this->get_option( 'username' );
 		$domain = ( defined( 'MAILGUN_DOMAIN' ) && MAILGUN_DOMAIN ) ? MAILGUN_DOMAIN : $this->get_option( 'domain' );
 		$username = preg_replace( '/@.+$/', '', $username ) . "@{$domain}";
@@ -84,7 +85,7 @@ class Mailgun {
 	 * @since 0.1
 	 * @return none
 	 */
-	function deactivate_and_die( $file ) {
+	public function deactivate_and_die( $file ) {
 		load_plugin_textdomain( 'mailgun', false, 'mailgun/languages' );
 		$message = sprintf( __( "Mailgun has been automatically deactivated because the file <strong>%s</strong> is missing. Please reinstall the plugin and reactivate." ), $file );
 		if ( ! function_exists( 'deactivate_plugins' ) )
@@ -92,7 +93,302 @@ class Mailgun {
 		deactivate_plugins( __FILE__ );
 		wp_die( $message );
 	}
+	
+	/**
+	 * Make a Mailgun api call
+	 *
+	 * @param string $endpoint The Mailgun endpoint uri
+	 * @return array
+	 * @since 0.1
+	 */	
+	public function api_call($uri, $params = array(), $method = 'POST') {
+		
+		$options = get_option( 'mailgun' );
+		$apiKey = ( defined( 'MAILGUN_APIKEY' ) && MAILGUN_APIKEY ) ? MAILGUN_APIKEY : $options['apiKey'];
+		$domain = ( defined( 'MAILGUN_DOMAIN' ) && MAILGUN_DOMAIN ) ? MAILGUN_DOMAIN : $options['domain'];
+		
+		$time = time();
+		$url = $this->api_endpoint . $uri;
+		$headers = array('Authorization' => 'Basic ' . base64_encode( "api:{$apiKey}"));
 
+		switch ($method) {
+			case 'GET':
+				$params['sess'] = '';
+				$querystring = http_build_query($params);
+				$url = $url.'?'.$querystring;
+				$params = '';
+				break;
+			case 'POST':
+			case 'PUT':
+			case 'DELETE':
+				$params['sess'] = '';
+				$params['time'] = $time;
+				$params['hash'] = sha1(date('U'));
+				break;
+		}
+		
+		// make the request
+		$args = array(
+			'method' => $method,
+			'body' => $params,
+			'headers' => $headers,
+			'sslverify' => true
+		);
+		
+		// make the remote request
+		$result = wp_remote_request($url, $args);
+		if ( !is_wp_error($result) ) {
+			return $result['body'];
+		} else {
+			return $result->get_error_message();
+		}
+		
+	}
+
+	/**
+	 * Get account associated lists
+	 *
+	 * @return array
+	 * @since 0.1
+	 */	
+	public function get_lists() {
+		
+		$results = array();
+		
+		$lists_json = $this->api_call("lists", array(), 'GET');
+		$lists_arr = json_decode($lists_json, true);
+		if( isset($lists_arr['items']) && !empty($lists_arr['items']) ){
+			$results = $lists_arr['items'];
+		}
+		
+		return $results;
+	}
+
+	/**
+	 * Handle add list ajax post
+	 *
+	 * @return string json
+	 * @since 0.1
+	 */
+	public function add_list() {
+
+		$response = array();
+
+		$name = isset($_POST['name']) ? $_POST['name'] : null;
+		$email = isset($_POST['email']) ? $_POST['email'] : null;
+
+		$list_addresses = $_POST['addresses'];
+
+		if( ! empty($list_addresses)) {
+
+			foreach($list_addresses as $address => $val) {
+
+				$response[] = $this->api_call(
+					"lists/{$address}/members",
+					array(
+						'address' => $email,
+						'name'	  => $name
+					)
+				);
+
+			}
+
+			echo json_encode(array('status' => 200, 'message' => 'Thank you!'));
+
+		} else {
+
+			echo json_encode(array('status' => 500, 'message' => 'Uh oh. We weren\'t able to add you to the list' . count($list_addresses) ? 's.' : '. Please try again.'));
+		}
+
+		wp_die();
+	}
+
+	/**
+	 * Frontend List Form
+	 *
+	 * @param string $list_address Mailgun address list id
+	 * @param array $args widget arguments
+	 * @param string $instance widget instance params
+	 * @since 0.1
+	 */	
+	public function list_form($list_address, $args = array(), $instance = array()) {
+
+		$widget_class_id = "mailgun-list-widget-{$args['widget_id']}";
+		$form_class_id = "list-form-{$args['widget_id']}";
+
+		// List addresses from the plugin config
+		$list_addresses = array_map('trim', explode(',', $list_address));
+
+		// All list info from the API; used for list info when more than one list is available to subscribe to
+		$all_list_addresses = $this->get_lists();
+
+		?>
+		<div class="mailgun-list-widget-front <?php echo $widget_class_id; ?> widget">
+	        <form class="list-form <?php echo $form_class_id; ?>">
+	            <div class="mailgun-list-widget-inputs">
+	            	<?php if(isset($args['list_title']) ) : ?>
+			            <div class="mailgun-list-title">
+			            	<h4 class="widget-title">
+			            		<span><?php echo $args['list_title']; ?></span>
+			            	</h4>
+			            </div>
+		           	<?php endif; ?>
+		           	<?php if(isset($args['list_description']) ) : ?>
+			            <div class="mailgun-list-description">
+			            	<p class="widget-description">
+				            	<span><?php echo $args['list_description']; ?></span>
+				            </p>
+			            </div>
+		           	<?php endif; ?>
+	            	<?php if(isset($args['collect_name']) && intval($args['collect_name']) === 1) : ?>
+			            <p class="mailgun-list-widget-name">
+			            	<strong>Name:</strong>
+			            	<input type="text" name="name" />
+			            </p>
+		           	<?php endif; ?>
+		            <p class="mailgun-list-widget-email">
+		            	<strong>Email:</strong>
+		            	<input type="text" name="email" />
+		            </p>
+	            </div>
+
+	            <?php if(count($list_addresses) > 1) : ?>
+		            <ul class="mailgun-lists" style="list-style: none;">
+			           	<?php foreach($all_list_addresses as $la) : ?>
+			           		<?php if( ! in_array($la['address'], $list_addresses ) ) continue; ?>
+			           		<li>
+			           			<input type="checkbox" class="mailgun-list-name" name="addresses[<?=$la['address'];?>]" /> <?php echo $la['name']; ?>
+			           		</li>
+			            <?php endforeach; ?>
+		          	</ul>
+		        <?php else : ?>
+			        <input type="hidden" name="addresses[<?=$list_addresses[0];?>]" value="on" />
+		    	<?php endif; ?>
+
+				<input class="mailgun-list-submit-button" data-form-id="<?php echo $form_class_id; ?>" type="button" value="Subscribe" />
+	            <input type="hidden" name="mailgun-submission" value="1" />
+
+	        </form>
+	        <div class="widget-list-panel result-panel" style="display:none;">
+		   		<span>Thank you for subscribing!</span>
+			</div>
+		</div>
+	        
+		<script>
+
+		jQuery(document).ready(function(){
+
+			jQuery('.mailgun-list-submit-button').on('click', function() {
+
+				var form_id = jQuery(this).data('form-id');
+
+				if(jQuery('.mailgun-list-name').length > 0 && jQuery('.'+form_id+' .mailgun-list-name:checked').length < 1) {
+					alert('Please select a list to subscribe to.');
+					return;
+				}
+
+				if(jQuery('.'+form_id+' .mailgun-list-widget-name input') && jQuery('.'+form_id+' .mailgun-list-widget-name input').val() === '') {
+					alert('Please enter your subscription name.');
+					return;
+				}
+
+				if(jQuery('.'+form_id+' .mailgun-list-widget-email input').val() === '') {
+					alert('Please enter your subscription email.');
+					return;
+				}
+
+				jQuery.ajax({
+			        url: '<?php echo admin_url('admin-ajax.php?action=add_list'); ?>',
+			        action:'add_list',
+			        type: 'post',
+			        dataType: 'json',
+			        data: jQuery('.'+form_id+'').serialize(),
+			        success: function(data) {
+
+						data_msg = data.message;
+						already_exists = false;
+						if(data_msg !== undefined){
+							already_exists = data_msg.indexOf('Address already exists') > -1;
+						}
+				        
+						// success
+						if((data.status === 200)) {
+							jQuery('.<?php echo $widget_class_id; ?> .widget-list-panel').css('display', 'none');
+							jQuery('.<?php echo $widget_class_id; ?> .list-form').css('display', 'none');
+							jQuery('.<?php echo $widget_class_id; ?> .result-panel').css('display', 'block');
+						// error
+						} else {
+							alert(data_msg);
+						}
+					}
+			    });
+			});
+		});
+
+		</script>
+		
+		<?php
+	}	
+	
+	/**
+	 * Initialize List Form
+	 *
+	 * @param array $atts Form attributes
+	 * @since 0.1
+	 */	
+	public function build_list_form($atts) {
+
+		if(isset($atts['id']) && $atts['id'] != '' ) {
+
+			$args['widget_id'] = md5(rand(10000, 99999) + $atts['id']);
+
+			if( isset($atts['collect_name']) ) {
+				$args['collect_name'] = true;
+			}
+
+			if( isset($atts['title']) ) {
+				$args['list_title'] = $atts['title'];
+			}
+
+			if( isset($atts['description']) ) {
+				$args['list_description'] = $atts['description'];
+			}
+
+			ob_start();
+			$this->list_form($atts['id'], $args);
+			$output_string = ob_get_contents();;
+			ob_end_clean();
+
+			return $output_string;
+
+		} else {
+
+			?>
+			<span>Mailgun list ID needed to render form!</span>
+			<br />
+			<strong>Example :</strong> [mailgun id="[your list id]"]
+			<?php
+		}
+	}	
+	
+	/**
+	 * Initialize List Widget
+	 *
+	 * @since 0.1
+	 */	
+	public function load_list_widget() {
+		register_widget('list_widget');
+		add_shortcode('mailgun', array(&$this, 'build_list_form'));
+	}	
+	
+}
+
+$mailgun = new Mailgun();
+
+if ( @include( dirname( __FILE__ ) . '/includes/widget.php' ) ) {
+	add_action('widgets_init', array(&$mailgun, 'load_list_widget'));
+	add_action('wp_ajax_nopriv_add_list', array(&$mailgun, 'add_list'));
+	add_action('wp_ajax_add_list', array(&$mailgun, 'add_list'));
 }
 
 if ( is_admin() ) {
@@ -101,6 +397,8 @@ if ( is_admin() ) {
 	} else {
 		Mailgun::deactivate_and_die( dirname( __FILE__ ) . '/includes/admin.php' );
 	}
-} else {
-	$mailgun = new Mailgun();
 }
+
+
+
+

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,12 @@
 === Mailgun for WordPress ===
-Contributors: sivel, Mailgun
+Contributors: Mailgun, sivel, lookahead.io, m35dev
 Tags: mailgun, smtp, http, api, mail, email
 Requires at least: 3.3
-Tested up to: 3.5
-Stable tag: 1.0
+Tested up to: 4.3
+Stable tag: 1.4.1
 License: GPLv2 or later
 
-Easily send email from your WordPress site through Mailgun using the HTTP API or SMTP.
+Easily send email from your WordPress site through Mailgun using the HTTP API or SMTP. And now, the plugin supports Mailgun List subscription allowing your visitors to subscribe to one or more e-mail lists via widgets or shortcodes.
 
 == Description ==
 
@@ -14,13 +14,17 @@ Easily send email from your WordPress site through Mailgun using the HTTP API or
 
 One particularly useful feature of this plugin is that it provides you with a way to send email when the server you are on does not support SMTP or where outbound SMTP is restricted since the plug-in uses the Mailgun HTTP API for sending email by default. All you need to use the plugin is a [Mailgun account](http://www.mailgun.com/). Mailgun has a free account that lets you send up to 200 emails per day, which is great for testing. Paid subscriptions are available for increased limits.
 
-The current version of this plugin only handles sending emails. Future releases will include additional functionality around processing incoming emails, tracking and analytics. Until then, you can configure how to handle incoming emails and set up analytics in the Mailgun control panel or using the Mailgun API.
+The latest version of this plugin adds support for Mailgun list subscription. Using the shortcode, you can place a form on an article or page to allow the visitor to subscribe to one or more lists. Using the widget, you can provide subscription functionality in sidebars or anywhere widgets are supported e.g. footers.
+
+The current version of this plugin only handles sending emails, tracking and tagging and list subscription. 
 
 == Installation ==
 
 1. Upload the `mailgun` folder to the `/wp-content/plugins/` directory or install directly through the plugin installer
-1. Activate the plugin through the 'Plugins' menu in WordPress or by using the link provided by the plugin installer
-1. Visit the settings page in the Admin at `Settings -> Mailgun` and configure the plugin with your account details
+2. Activate the plugin through the 'Plugins' menu in WordPress or by using the link provided by the plugin installer
+3. Visit the settings page in the Admin at `Settings -> Mailgun` and configure the plugin with your account details
+4. Click the Test Configuration button to verify that your settings are correct.
+5. Click View Available Lists to review shortcode settings for lists in your Mailgun account that you may wish to help users subscribe to
 
 == Frequently Asked Questions ==
 
@@ -49,6 +53,10 @@ MAILGUN_SECURE   Type: boolean
 
 1. Configuration options for using the Mailgun HTTP API
 2. Configuration options for using the Mailgun SMTP servers
+3. Administration option to View Available Lists for subscription
+4. Setting up a Subscription Widget
+5. Using a Subscription Code
+6. Subscription Form Seen By Site Visitors
 
 == Upgrade Notice ==
 
@@ -61,6 +69,27 @@ Re-release to update versioning to start at 1.0 instead of 0.1
 Initial Release
 
 == ChangeLog ==
+
+= 1.4.1 (2015-12-01): = 
+* Clarify compatibility with WordPress 4.3 
+
+= 1.4 (2015-11-15): =
+* Added shortcode and widget support for list subscription
+
+= 1.3.1 (2014-11-19): =
+* Switched to Semantic Versioning
+* Fixed issue with campaigns and tags
+
+= 1.3 (2014-08-25): =
+* Added check to ignore empty attachments
+
+= 1.2 (2014-08-19): =
+* Fixed errors related to undefined variable. https://github.com/mailgun/wordpress-plugin/pull/3
+
+= 1.1 (2013-12-09): =
+* Attachments are now handled properly.
+* Added ability to customize tags and campaigns.
+* Added ability to toggle URL and open tracking.
 
 = 1.0 (2012-11-27): =
 * Re-release to update versioning to start at 1.0 instead of 0.1


### PR DESCRIPTION
Hi,
I noticed that this repo was out of date, so I first updated it to the latest version.

The bug itself was in the wp-mail.php file (please see the second commit). It prevented the user from seeing success message on sending the test email, when php warnings were turned on. The warning message was part of the response, thus the test always "failed" even though the mail was sent successfully.
