### PR TITLE
Add default o:tag value to wp-mail.php

### DIFF
--- a/includes/wp-mail.php
+++ b/includes/wp-mail.php
@@ -139,6 +139,7 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
 		'text' => $message
 	);
 
+	$body['o:tag'] = '';
 	$body['o:tracking-clicks'] = isset( $mailgun['track-clicks'] ) ? $mailgun['track-clicks'] : "no";
 	$body['o:tracking-opens'] = isset( $mailgun['track-opens'] ) ? "yes" : "no";
 


### PR DESCRIPTION
This resolves the 'o:tag' error which has been [flagged as an issue here](https://github.com/mailgun/wordpress-plugin/issues/15)