### PR TITLE
1.5.3 plugin release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.5.3 (2016-12-22):
+* Changed all bracketed array usages to `array()` syntax for older PHP support
+* Redesigned `Content-Type` processing code to not make such large assumptions
+* Mailgun logo is now loaded over HTTPS
+* Fixed undefined variable issue with from email / from name code
+
 1.5.2 (2016-12-22):
 * Added option fields for setting a From name and address
 

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -36,18 +36,18 @@ class MailgunAdmin extends Mailgun
         load_plugin_textdomain('mailgun', false, 'mailgun/languages');
 
         // Activation hook
-        register_activation_hook($this->plugin_file, [&$this, 'init']);
+        register_activation_hook($this->plugin_file, array(&$this, 'init'));
 
         if (!defined('MAILGUN_USEAPI') || !MAILGUN_USEAPI) {
             // Hook into admin_init and register settings and potentially register an admin_notice
-            add_action('admin_init', [&$this, 'admin_init']);
+            add_action('admin_init', array(&$this, 'admin_init'));
 
             // Activate the options page
-            add_action('admin_menu', [&$this, 'admin_menu']);
+            add_action('admin_menu', array(&$this, 'admin_menu'));
         }
 
         // Register an AJAX action for testing mail sending capabilities
-        add_action('wp_ajax_mailgun-test', [&$this, 'ajax_send_test']);
+        add_action('wp_ajax_mailgun-test', array(&$this, 'ajax_send_test'));
     }
 
     /**
@@ -92,11 +92,11 @@ class MailgunAdmin extends Mailgun
     public function admin_menu()
     {
         if (current_user_can('manage_options')) {
-            $this->hook_suffix = add_options_page(__('Mailgun', 'mailgun'), __('Mailgun', 'mailgun'), 'manage_options', 'mailgun', [&$this, 'options_page']);
-            add_options_page(__('Mailgun Lists', 'mailgun'), __('Mailgun Lists', 'mailgun'), 'manage_options', 'mailgun-lists', [&$this, 'lists_page']);
-            add_action("admin_print_scripts-{$this->hook_suffix}", [&$this, 'admin_js']);
-            add_filter("plugin_action_links_{$this->plugin_basename}", [&$this, 'filter_plugin_actions']);
-            add_action("admin_footer-{$this->hook_suffix}", [&$this, 'admin_footer_js']);
+            $this->hook_suffix = add_options_page(__('Mailgun', 'mailgun'), __('Mailgun', 'mailgun'), 'manage_options', 'mailgun', array(&$this, 'options_page'));
+            add_options_page(__('Mailgun Lists', 'mailgun'), __('Mailgun Lists', 'mailgun'), 'manage_options', 'mailgun-lists', array(&$this, 'lists_page'));
+            add_action("admin_print_scripts-{$this->hook_suffix}", array(&$this, 'admin_js'));
+            add_filter("plugin_action_links_{$this->plugin_basename}", array(&$this, 'filter_plugin_actions'));
+            add_action("admin_footer-{$this->hook_suffix}", array(&$this, 'admin_footer_js'));
         }
     }
 
@@ -224,7 +224,7 @@ class MailgunAdmin extends Mailgun
         $useAPI = $this->get_option('useAPI');
         $password = $this->get_option('password');
         if ((empty($apiKey) && $useAPI == '1') || (empty($password) && $useAPI == '0')) {
-            add_action('admin_notices', [&$this, 'admin_notices']);
+            add_action('admin_notices', array(&$this, 'admin_notices'));
         }
     }
 
@@ -237,7 +237,7 @@ class MailgunAdmin extends Mailgun
      */
     public function register_settings()
     {
-        register_setting('mailgun', 'mailgun', [&$this, 'validation']);
+        register_setting('mailgun', 'mailgun', array(&$this, 'validation'));
     }
 
     /**

--- a/includes/lists-page.php
+++ b/includes/lists-page.php
@@ -44,7 +44,7 @@ $lists_arr = $mailgun->get_lists();
 
     <span class="alignright">
         <a target="_blank" href="http://www.mailgun.com/">
-            <img src="http://www.mailgun.com/static/img/mailgun.svg" alt="Mailgun" style="width: 10em;"/>
+            <img src="https://www.mailgun.com/static/img/mailgun.svg" alt="Mailgun" style="width: 10em;"/>
         </a>
     </span>
 

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -22,7 +22,7 @@
 ?>
         <div class="wrap">
             <div id="icon-options-general" class="icon32"><br /></div>
-            <span class="alignright"><a target="_blank" href="http://www.mailgun.com/"><img src="http://www.mailgun.com/static/img/mailgun.svg" alt="Mailgun" style="width: 10em;"/></a></span>
+            <span class="alignright"><a target="_blank" href="http://www.mailgun.com/"><img src="https://www.mailgun.com/static/img/mailgun.svg" alt="Mailgun" style="width: 10em;"/></a></span>
             <h2><?php _e('Mailgun', 'mailgun'); ?></h2>
             <p>A <a target="_blank" href="http://www.mailgun.com/">Mailgun</a> account is required to use this plugin and the Mailgun service.</p>
             <p>If you need to register for an account, you can do so at <a target="_blank" href="http://www.mailgun.com/">http://www.mailgun.com/</a>.</p>

--- a/includes/widget.php
+++ b/includes/widget.php
@@ -29,7 +29,7 @@ class list_widget extends WP_Widget
             // Widget name will appear in UI
             __('Mailgun List Widget', 'wpb_widget_domain'),
             // Widget description
-            ['description' => __('Mailgun list widget', 'wpb_widget_domain')]
+            array('description' => __('Mailgun list widget', 'wpb_widget_domain'))
         );
     }
 

--- a/mailgun.php
+++ b/mailgun.php
@@ -23,7 +23,7 @@
  * Plugin Name:  Mailgun
  * Plugin URI:   http://wordpress.org/extend/plugins/mailgun/
  * Description:  Mailgun integration for WordPress
- * Version:      1.5.2
+ * Version:      1.5.3
  * Author:       Mailgun
  * Author URI:   http://www.mailgun.com/
  * License:      GPLv2 or later
@@ -55,7 +55,7 @@ class Mailgun
                 }
             }
         } else {
-            add_action('phpmailer_init', [&$this, 'phpmailer_init']);
+            add_action('phpmailer_init', array(&$this, 'phpmailer_init'));
         }
     }
 
@@ -226,9 +226,9 @@ class Mailgun
                 );
             }
 
-            echo json_encode(['status' => 200, 'message' => 'Thank you!']);
+            echo json_encode(array('status' => 200, 'message' => 'Thank you!'));
         } else {
-            echo json_encode(['status' => 500, 'message' => 'Uh oh. We weren\'t able to add you to the list'.count($list_addresses) ? 's.' : '. Please try again.']);
+            echo json_encode(array('status' => 500, 'message' => 'Uh oh. We weren\'t able to add you to the list'.count($list_addresses) ? 's.' : '. Please try again.'));
         }
 
         wp_die();
@@ -411,16 +411,16 @@ class Mailgun
     public function load_list_widget()
     {
         register_widget('list_widget');
-        add_shortcode('mailgun', [&$this, 'build_list_form']);
+        add_shortcode('mailgun', array(&$this, 'build_list_form'));
     }
 }
 
 $mailgun = new Mailgun();
 
 if (@include dirname(__FILE__).'/includes/widget.php') {
-    add_action('widgets_init', [&$mailgun, 'load_list_widget']);
-    add_action('wp_ajax_nopriv_add_list', [&$mailgun, 'add_list']);
-    add_action('wp_ajax_add_list', [&$mailgun, 'add_list']);
+    add_action('widgets_init', array(&$mailgun, 'load_list_widget'));
+    add_action('wp_ajax_nopriv_add_list', array(&$mailgun, 'add_list'));
+    add_action('wp_ajax_add_list', array(&$mailgun, 'add_list'));
 }
 
 if (is_admin()) {

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Contributors: Mailgun, sivel, lookahead.io, m35dev
 Tags: mailgun, smtp, http, api, mail, email
 Requires at least: 3.3
 Tested up to: 4.7
-Stable tag: 1.5.2
+Stable tag: 1.5.3
 License: GPLv2 or later
 
 
@@ -67,6 +67,12 @@ MAILGUN_SECURE   Type: boolean
 
 
 == Changelog ==
+
+= 1.5.3 (2016-12-22): =
+* Changed all bracketed array usages to `array()` syntax for older PHP support
+* Redesigned `Content-Type` processing code to not make such large assumptions
+* Mailgun logo is now loaded over HTTPS
+* Fixed undefined variable issue with from email / from name code
 
 = 1.5.2 (2016-12-22): =
 * Added option fields for setting a From name and address


### PR DESCRIPTION
* Changed all bracketed array usages to `array()` syntax for older PHP support
* Redesigned `Content-Type` processing code to not make such large assumptions
* Mailgun logo is now loaded over HTTPS
* Fixed undefined variable issue with from email / from name code