### PR TITLE
Respect wp_mail_content_type filter

### DIFF
--- a/includes/wp-mail.php
+++ b/includes/wp-mail.php
@@ -276,6 +276,14 @@ function wp_mail($to, $subject, $message, $headers = '', $attachments = array())
         $body['bcc'] = implode(', ', $bcc);
     }
 
+    // Allow external content type filter to function normally 
+    if (has_filter('wp_mail_content_type')) {
+        $content_type = apply_filters(
+            'wp_mail_content_type',
+            $content_type
+        );
+    }
+    
     // If we are not given a Content-Type from the supplied headers, use
     // text/html and *attempt* to strip tags and provide a text/plain
     // version.


### PR DESCRIPTION
For some systems, the content type detection updates made in 1.5.1 have proven problematic. This plugin has been missing support for wp_mail_content_type; just like respecting wp_mail_from and wp_mail_from_name, it is good practice to respect this filter, and doing so can allow a quick fix for those systems with issues.