### PR TITLE
1.5.6 (2016-12-30)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.5.6 (2016-12-30):
+* Fix a very subtle bug causing fatal errors with older PHP versions < 5.5
+* Respect `wp_mail_content_type` (#37 - @FPCSJames)
+
 1.5.5 (2016-12-27):
 * Restructure the `admin_notices` code
 * Restructure the "From Name" / "From Address" code

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -295,21 +295,22 @@ class MailgunAdmin extends Mailgun
             return;
         }
 
-        if ((empty($this->get_option('apiKey')) && $this->get_option('useAPI') == '1')
-            || (empty($this->get_option('password')) && $this->get_option('useAPI') == '0')
+        if ((!$this->get_option('apiKey') && $this->get_option('useAPI') === '1')
+            || (!$this->get_option('password') && $this->get_option('useAPI') === '0')
         ) { ?>
             <div id='mailgun-warning' class='updated fade'><p><strong><?php _e('Mailgun is almost ready. ', 'mailgun'); ?></strong><?php printf(__('You must <a href="%1$s">configure Mailgun</a> for it to work.', 'mailgun'), menu_page_url('mailgun', false)); ?></p></div>
 <?php
         }
 
         if ($this->get_option('override-from') === '1'
-            && (empty($this->get_option('from-name'))
-            || empty($this->get_option('from-address')))
+            && (!$this->get_option('from-name')
+            || !$this->get_option('from-address'))
         ) { ?>
             <div id='mailgun-warning' class='updated fade'><p><strong><?php _e('Mailgun is almost ready. ', 'mailgun'); ?></strong><?php printf(__('"Override From" option requires that "From Name" and "From Address" be set to work properly! <a href="%1$s">Configure Mailgun now</a>.', 'mailgun'), menu_page_url('mailgun', false)); ?></p></div>
 <?php
         }
     }
+
 
     /**
      * Add a settings link to the plugin actions.

--- a/mailgun.php
+++ b/mailgun.php
@@ -4,7 +4,7 @@
  * Plugin Name:  Mailgun
  * Plugin URI:   http://wordpress.org/extend/plugins/mailgun/
  * Description:  Mailgun integration for WordPress
- * Version:      1.5.5
+ * Version:      1.5.6
  * Author:       Mailgun
  * Author URI:   http://www.mailgun.com/
  * License:      GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Contributors: Mailgun, sivel, lookahead.io, m35dev
 Tags: mailgun, smtp, http, api, mail, email
 Requires at least: 3.3
 Tested up to: 4.7
-Stable tag: 1.5.5
+Stable tag: 1.5.6
 License: GPLv2 or later
 
 
@@ -67,6 +67,10 @@ MAILGUN_SECURE   Type: boolean
 
 
 == Changelog ==
+
+= 1.5.6 (2016-12-30): =
+* Fix a very subtle bug causing fatal errors with older PHP versions < 5.5
+* Respect `wp_mail_content_type` (#37 - @FPCSJames)
 
 = 1.5.5 (2016-12-27): =
 * Restructure the `admin_notices` code


### PR DESCRIPTION
* Fix a very subtle bug causing fatal errors with older PHP versions < 5.5
* Respect `wp_mail_content_type` (#37 - @FPCSJames)