### PR TITLE
1.5.7.1 (2017-01-18):

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+1.5.7.1 (2017-01-18):
+* Fix an odd `Undefined property: MailgunAdmin::$defaults` when saving config
+* Fix strict mode notice for using `$mailgun['override-from']` without checking `isset`
+
 1.5.7 (2017-01-04):
 * Add better support for using recipient variables for batch mailing.
 * Clarify wording on `From Address` note

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -22,6 +22,11 @@
 class MailgunAdmin extends Mailgun
 {
     /**
+     * @var array $defaults Array of "safe" option defaults.
+     */
+    private $defaults;
+
+    /**
      * Setup backend functionality in WordPress.
      *
      * @return none

--- a/includes/wp-mail.php
+++ b/includes/wp-mail.php
@@ -223,8 +223,8 @@ function wp_mail($to, $subject, $message, $headers = '', $attachments = array())
         }
     }
 
-    if ($mailgun['override-from'] && !empty($mailgun['from-name'])
-        && !empty($mailgun['from-address'])
+    if ((isset($mailgun['override-from']) && $mailgun['override-from'])
+        && !empty($mailgun['from-name']) && !empty($mailgun['from-address'])
     ) {
         $from_name = $mailgun['from-name'];
         $from_email = $mailgun['from-address'];

--- a/mailgun.php
+++ b/mailgun.php
@@ -4,7 +4,7 @@
  * Plugin Name:  Mailgun
  * Plugin URI:   http://wordpress.org/extend/plugins/mailgun/
  * Description:  Mailgun integration for WordPress
- * Version:      1.5.7
+ * Version:      1.5.7.1
  * Author:       Mailgun
  * Author URI:   http://www.mailgun.com/
  * License:      GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Contributors: Mailgun, sivel, lookahead.io, m35dev
 Tags: mailgun, smtp, http, api, mail, email
 Requires at least: 3.3
 Tested up to: 4.7.1
-Stable tag: 1.5.7
+Stable tag: 1.5.7.1
 License: GPLv2 or later
 
 
@@ -69,6 +69,10 @@ MAILGUN_FROM_ADDRESS Type: string
 
 
 == Changelog ==
+
+= 1.5.7.1 (2017-01-18): =
+* Fix an odd `Undefined property: MailgunAdmin::$defaults` when saving config
+* Fix strict mode notice for using `$mailgun['override-from']` without checking `isset`
 
 = 1.5.7 (2017-01-04): =
 * Add better support for using recipient variables for batch mailing.


### PR DESCRIPTION
* Fix an odd `Undefined property: MailgunAdmin::$defaults` when saving config
* Fix strict mode notice for using `$mailgun['override-from']` without checking `isset`

------

Both changes originate from PR #41.

------

This is a bugfix release.
**STATUS**: STABLE