### PR TITLE
1.5.8.1 (02-02-17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.5.8.1 (2017-02-06):
+- Fix "Undefined property: MailgunAdmin::$hook_suffix" (#48)
+- Fix "Undefined variable: from_name on every email process" (API and SMTP) (#49)
+- Admin code now loads only on admin user access
+
 1.5.8 (2017-01-23):
 * Rewrite a large chunk of old SMTP code
 * Fix a bug with SMTP + "override from" that was introduced in 1.5.7

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -306,7 +306,8 @@ class MailgunAdmin extends Mailgun
     public function admin_notices()
     {
         $screen = get_current_screen();
-        if ($screen->id == $this->hook_suffix) {
+        if (!current_user_can('manage_options') || $screen->id == $this->hook_suffix
+        ) {
             return;
         }
 
@@ -314,7 +315,7 @@ class MailgunAdmin extends Mailgun
             || (!$this->get_option('password') && $this->get_option('useAPI') === '0')
         ) {
             ?>
-            <div id='mailgun-warning' class='updated fade'><p><strong><?php _e('Mailgun is almost ready. ', 'mailgun'); ?></strong><?php printf(__('You must <a href="%1$s">configure Mailgun</a> for it to work.', 'mailgun'), menu_page_url('mailgun', false)); ?></p></div>
+            <div id='mailgun-warning' class='notice notice-warning fade'><p><strong><?php _e('Mailgun is almost ready. ', 'mailgun'); ?></strong><?php printf(__('You must <a href="%1$s">configure Mailgun</a> for it to work.', 'mailgun'), menu_page_url('mailgun', false)); ?></p></div>
 <?php
 
         }
@@ -324,7 +325,7 @@ class MailgunAdmin extends Mailgun
             || !$this->get_option('from-address'))
         ) {
             ?>
-            <div id='mailgun-warning' class='updated fade'><p><strong><?php _e('Mailgun is almost ready. ', 'mailgun'); ?></strong><?php printf(__('"Override From" option requires that "From Name" and "From Address" be set to work properly! <a href="%1$s">Configure Mailgun now</a>.', 'mailgun'), menu_page_url('mailgun', false)); ?></p></div>
+            <div id='mailgun-warning' class='notice notice-warning fade'><p><strong><?php _e('Mailgun is almost ready. ', 'mailgun'); ?></strong><?php printf(__('"Override From" option requires that "From Name" and "From Address" be set to work properly! <a href="%1$s">Configure Mailgun now</a>.', 'mailgun'), menu_page_url('mailgun', false)); ?></p></div>
 <?php
 
         }

--- a/includes/wp-mail-api.php
+++ b/includes/wp-mail-api.php
@@ -203,6 +203,14 @@ function wp_mail($to, $subject, $message, $headers = '', $attachments = array())
         }
     }
 
+    if (!isset($from_name)) {
+        $from_name = null;
+    }
+
+    if (!isset($from_email)) {
+        $from_email = null;
+    }
+
     $from_name = mg_detect_from_name($from_name);
     $from_email = mg_detect_from_address($from_email);
 

--- a/includes/wp-mail-smtp.php
+++ b/includes/wp-mail-smtp.php
@@ -128,6 +128,14 @@ function mg_smtp_mail_filter(array $args)
         }
     }
 
+    if (!isset($from_name)) {
+        $from_name = null;
+    }
+
+    if (!isset($from_email)) {
+        $from_email = null;
+    }
+
     $from_name = mg_detect_from_name($from_name);
     $from_addr = mg_detect_from_address($from_addr);
 

--- a/mailgun.php
+++ b/mailgun.php
@@ -4,7 +4,7 @@
  * Plugin Name:  Mailgun
  * Plugin URI:   http://wordpress.org/extend/plugins/mailgun/
  * Description:  Mailgun integration for WordPress
- * Version:      1.5.8
+ * Version:      1.5.8.1
  * Author:       Mailgun
  * Author URI:   http://www.mailgun.com/
  * License:      GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Contributors: Mailgun, sivel, lookahead.io, m35dev
 Tags: mailgun, smtp, http, api, mail, email
 Requires at least: 3.3
 Tested up to: 4.7.1
-Stable tag: 1.5.8
+Stable tag: 1.5.8.1
 License: GPLv2 or later
 
 
@@ -75,6 +75,11 @@ MAILGUN_FROM_ADDRESS Type: string
 
 
 == Changelog ==
+
+= 1.5.8.1 (2017-02-06): =
+- Fix "Undefined property: MailgunAdmin::$hook_suffix" (#48)
+- Fix "Undefined variable: from_name on every email process" (API and SMTP) (#49)
+- Admin code now loads only on admin user access
 
 = 1.5.8 (2017-01-23): =
 * Rewrite a large chunk of old SMTP code


### PR DESCRIPTION
(yet another bugfix release, pt. 1)
- Fix "Undefined property: MailgunAdmin::$hook_suffix" (#48)
- Fix "Undefined variable: from_name on every email process" (#49)

----
#### Known Issues

When `Override "From" Details` is enabled and the detail fields are not configured (ie., the admin notice is showing), submitting user creation, user editing pages does not complete - queries happen and changes are made, but the next page *does not* render...

EDIT: It also appears the above happens only when sending via SMTP is enabled...

----

/cc @abdusfauzi