### PR TITLE
1.5.8.2 minor release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.5.8.2 (2017-02-27):
+- Fix a bug causing empty tags to be sent with messages (#51)
+- Add `mg_mutate_message_body` hook to allow other plugins to modify the message body before send
+- Add `mg_mutate_attachments` hook to allow other plugins to modify the message attachments before send
+- Fix a bug causing the AJAX test to fail incorrectly.
+
 1.5.8.1 (2017-02-06):
 - Fix "Undefined property: MailgunAdmin::$hook_suffix" (#48)
 - Fix "Undefined variable: from_name on every email process" (API and SMTP) (#49)

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -389,8 +389,20 @@ class MailgunAdmin extends Mailgun
         );
 
         if ((bool) $useAPI) {
+            if (!function_exists('mg_api_last_error')) {
+                if (!include dirname(__FILE__).'/wp-mail-api.php') {
+                    self::deactivate_and_die(dirname(__FILE__).'/wp-mail-api.php');
+                }
+            }
+
             $error_msg = mg_api_last_error();
         } else {
+            if (!function_exists('mg_smtp_last_error')) {
+                if (!include dirname(__FILE__).'/wp-mail-smtp.php') {
+                    self::deactivate_and_die(dirname(__FILE__).'/wp-mail-smtp.php');
+                }
+            }
+
             $error_msg = mg_smtp_last_error();
         }
 

--- a/includes/wp-mail-api.php
+++ b/includes/wp-mail-api.php
@@ -226,7 +226,7 @@ function wp_mail($to, $subject, $message, $headers = '', $attachments = array())
         $body['recipient-variables'] = $rcpt_data['rcpt_vars'];
     }
 
-    $body['o:tag'] = '';
+    $body['o:tag'] = array();
     $body['o:tracking-clicks'] = !empty($mailgun['track-clicks']) ? $mailgun['track-clicks'] : 'no';
     $body['o:tracking-opens'] = empty($mailgun['track-opens']) ? 'no' : 'yes';
 
@@ -237,7 +237,7 @@ function wp_mail($to, $subject, $message, $headers = '', $attachments = array())
     }
 
     // campaign-id now refers to a list of tags which will be appended to the site tag
-    if (isset($mailgun['campaign-id'])) {
+    if (!empty($mailgun['campaign-id'])) {
         $tags = explode(',', str_replace(' ', '', $mailgun['campaign-id']));
         if (empty($body['o:tag'])) {
             $body['o:tag'] = $tags;
@@ -325,6 +325,9 @@ function wp_mail($to, $subject, $message, $headers = '', $attachments = array())
 
     $payload = null;
 
+    // Allow other plugins to apply body changes before writing the payload.
+    $body = apply_filters('mg_mutate_message_body', $body);
+
     // Iterate through pre-built params and build payload:
     foreach ($body as $key => $value) {
         if (is_array($value)) {
@@ -344,6 +347,9 @@ function wp_mail($to, $subject, $message, $headers = '', $attachments = array())
             $payload .= "\r\n";
         }
     }
+
+    // Allow other plugins to apply attachent changes before writing to the payload.
+    $attachments = apply_filters('mg_mutate_attachments', $attachments);
 
     // If we have attachments, add them to the payload.
     if (!empty($attachments)) {

--- a/mailgun.php
+++ b/mailgun.php
@@ -4,7 +4,7 @@
  * Plugin Name:  Mailgun
  * Plugin URI:   http://wordpress.org/extend/plugins/mailgun/
  * Description:  Mailgun integration for WordPress
- * Version:      1.5.8.1
+ * Version:      1.5.8.2
  * Author:       Mailgun
  * Author URI:   http://www.mailgun.com/
  * License:      GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Contributors: Mailgun, sivel, lookahead.io, m35dev
 Tags: mailgun, smtp, http, api, mail, email
 Requires at least: 3.3
 Tested up to: 4.7.1
-Stable tag: 1.5.8.1
+Stable tag: 1.5.8.2
 License: GPLv2 or later
 
 
@@ -63,6 +63,31 @@ MAILGUN_FROM_NAME    Type: string
 MAILGUN_FROM_ADDRESS Type: string
 `
 
+- What hooks are available for use with other plugins?
+
+`mg_use_recipient_vars_syntax`
+  Mutates messages to use recipient variables syntax - see
+  https://documentation.mailgun.com/user_manual.html#batch-sending for more info.
+
+  Should accept a list of `To` addressses.
+
+  Should *only* return `true` or `false`.
+
+`mg_mutate_message_body`
+  Allows an external plugin to mutate the message body before sending.
+
+  Should accept an array, `$body`.
+
+  Should return a new array to replace `$body`.
+
+`mg_mutate_attachments`
+  Allows an external plugin to mutate the attachments on the message before
+  sending.
+
+  Should accept an array, `$attachments`.
+
+  Should return a new array to replace `$attachments`.
+
 
 == Screenshots ==
 
@@ -75,6 +100,12 @@ MAILGUN_FROM_ADDRESS Type: string
 
 
 == Changelog ==
+
+= 1.5.8.2 (2017-02-27): =
+- Fix a bug causing empty tags to be sent with messages (#51)
+- Add `mg_mutate_message_body` hook to allow other plugins to modify the message body before send
+- Add `mg_mutate_attachments` hook to allow other plugins to modify the message attachments before send
+- Fix a bug causing the AJAX test to fail incorrectly.
 
 = 1.5.8.1 (2017-02-06): =
 - Fix "Undefined property: MailgunAdmin::$hook_suffix" (#48)


### PR DESCRIPTION
- Fix a bug causing empty tags to be sent with messages (#51)
- Add `mg_mutate_message_body` hook to allow other plugins to modify the message body before send
- Add `mg_mutate_attachments` hook to allow other plugins to modify the message attachments before send

Hooks addition from: https://wordpress.org/support/topic/mailgun-emails-sending-as-plain-text/#post-8853815