### PR TITLE
Change the default click tracking dropdown to htmlonly.

### DIFF
--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -96,8 +96,8 @@
                         </th>
                         <td>
                             <select name="mailgun[track-clicks]">
-                                <option value="yes"<?php selected('yes', $this->get_option('track-clicks')); ?>><?php _e('Yes', 'mailgun'); ?></option>
                                 <option value="htmlonly"<?php selected('htmlonly', $this->get_option('track-clicks')); ?>><?php _e('HTML Only', 'mailgun'); ?></option>
+                                <option value="yes"<?php selected('yes', $this->get_option('track-clicks')); ?>><?php _e('Yes', 'mailgun'); ?></option>
                                 <option value="no"<?php selected('no', $this->get_option('track-clicks')); ?>><?php _e('No', 'mailgun'); ?></option>
                             </select>
                             <p class="description"><?php _e('If enabled, Mailgun will  and track links.', 'mailgun'); ?> <a href="http://documentation.mailgun.com/user_manual.html#tracking-clicks" target="_blank">Click Tracking Documentation</a></p>


### PR DESCRIPTION
This PR proposes changing the default selected click tracking option to `htmlonly` instead of `yes`. The default behavior of `yes` will mangle WordPress' default emails, especially the password reset email, which default to plain text. The links in these emails get changed, which is the correct behavior, but in plain text can look pretty scary to the end user. I think the default behavior should be set to the safer htmlonly. A more advanced user would change WordPress' emails to html and change this setting to yes or no as needed.