### PR TITLE
Fix back to settings link on lists page

### DIFF
--- a/includes/lists-page.php
+++ b/includes/lists-page.php
@@ -52,7 +52,7 @@ $lists_arr = $mailgun->get_lists();
 
     <?php settings_fields('mailgun'); ?>
 
-    <h3><?php _e('Available Mailing Lists', 'mailgun'); ?> | <a href="/wp-admin/options-general.php?page=mailgun">Back to settings</a></h3>
+    <h3><?php _e('Available Mailing Lists', 'mailgun'); ?> | <a href="<?php echo admin_url('options-general.php?page=mailgun'); ?>">Back to settings</a></h3>
 
     <p><?php _e("{$missing_error}You must use a valid Mailgun domain name and API key to access lists", 'mailgun'); ?></p>
 


### PR DESCRIPTION
This fixes installations where WP lives in a subfolder.