### PR TITLE
Make both US and EU server regions available

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -71,6 +71,7 @@ class MailgunAdmin extends Mailgun
 
         $this->defaults = array(
             'useAPI'            => '1',
+            'region'            => '',
             'apiKey'            => '',
             'domain'            => '',
             'username'          => '',

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -44,6 +44,18 @@
                     </tr>
                     <tr valign="top">
                         <th scope="row">
+                            <?php _e('Server Region', 'mailgun'); ?>
+                        </th>
+                        <td>
+                            <select id="mailgun-region" name="mailgun[region]">
+                                <option value=""<?php selected('', $this->get_option('region')); ?>><?php _e('US (North America)', 'mailgun'); ?></option>
+                                <option value="eu."<?php selected('eu.', $this->get_option('region')); ?>><?php _e('EU (Europe)', 'mailgun'); ?></option>
+                            </select>
+                            <p class="description"><?php _e('Please select the region where your domain is configured. Defaults to US', 'mailgun'); ?></p>
+                        </td>
+                    </tr>
+                    <tr valign="top">
+                        <th scope="row">
                             <?php _e('Mailgun Domain Name', 'mailgun'); ?>
                         </th>
                         <td>

--- a/includes/wp-mail-api.php
+++ b/includes/wp-mail-api.php
@@ -115,6 +115,7 @@ function wp_mail($to, $subject, $message, $headers = '', $attachments = array())
 
     $mailgun = get_option('mailgun');
     $apiKey = (defined('MAILGUN_APIKEY') && MAILGUN_APIKEY) ? MAILGUN_APIKEY : $mailgun['apiKey'];
+    $region = (defined('MAILGUN_REGION') && MAILGUN_REGION) ? MAILGUN_REGION : $mailgun['region'];
     $domain = (defined('MAILGUN_DOMAIN') && MAILGUN_DOMAIN) ? MAILGUN_DOMAIN : $mailgun['domain'];
 
     if (empty($apiKey) || empty($domain)) {
@@ -357,7 +358,7 @@ function wp_mail($to, $subject, $message, $headers = '', $attachments = array())
         ),
     );
 
-    $url = "https://api.mailgun.net/v3/{$domain}/messages";
+    $url = "https://api.{$region}mailgun.net/v3/{$domain}/messages";
 
     // TODO: Mailgun only supports 1000 recipients per request, since we are
     // overriding this function, let's add looping here to handle that

--- a/mailgun.php
+++ b/mailgun.php
@@ -52,7 +52,8 @@ class Mailgun
         $this->options = get_option('mailgun');
         $this->plugin_file = __FILE__;
         $this->plugin_basename = plugin_basename($this->plugin_file);
-        $this->api_endpoint = 'https://api.mailgun.net/v3/';
+        $region = $this->get_option('region');
+        $this->api_endpoint = "https://api.{$region}mailgun.net/v3/";
 
         // Either override the wp_mail function or configure PHPMailer to use the
         // Mailgun SMTP servers
@@ -111,6 +112,7 @@ class Mailgun
     public function phpmailer_init(&$phpmailer)
     {
         $username = (defined('MAILGUN_USERNAME') && MAILGUN_USERNAME) ? MAILGUN_USERNAME : $this->get_option('username');
+        $region = (defined('MAILGUN_REGION') && MAILGUN_REGION) ? MAILGUN_REGION : $this->get_option('region');
         $domain = (defined('MAILGUN_DOMAIN') && MAILGUN_DOMAIN) ? MAILGUN_DOMAIN : $this->get_option('domain');
         $username = preg_replace('/@.+$/', '', $username)."@{$domain}";
         $secure = (defined('MAILGUN_SECURE') && MAILGUN_SECURE) ? MAILGUN_SECURE : $this->get_option('secure');
@@ -118,7 +120,7 @@ class Mailgun
         $password = (defined('MAILGUN_PASSWORD') && MAILGUN_PASSWORD) ? MAILGUN_PASSWORD : $this->get_option('password');
 
         $phpmailer->Mailer = 'smtp';
-        $phpmailer->Host = 'smtp.mailgun.org';
+        $phpmailer->Host = "smtp.{$region}mailgun.org";
         $phpmailer->Port = (bool) $secure ? 465 : 587;
         $phpmailer->SMTPAuth = true;
         $phpmailer->Username = $username;

--- a/readme.txt
+++ b/readme.txt
@@ -55,6 +55,7 @@ Yes, using the following constants that can be placed in wp-config.php:
 `
 MAILGUN_USEAPI       Type: boolean
 MAILGUN_APIKEY       Type: string
+MAILGUN_REGION       Type: string   Choices: '' for US or 'eu.' for Europe
 MAILGUN_DOMAIN       Type: string
 MAILGUN_USERNAME     Type: string
 MAILGUN_PASSWORD     Type: string


### PR DESCRIPTION
Resolves #75 by adding an admin setting to allow the user to select their server region allowing the extension to be used with both US and EU servers.

The `value` of the select option is inserted into both the API url and the SMTP url. E.g. `us = ''` `eu = 'eu.'` with a trailing dot. This allows future regions to be added simply by including a new select option in the admin settings.

Tested with both US and EU API and SMTP options.