### PR TITLE
Admin notifications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,11 @@
 Changelog
 =========
 
-1.5.13.2 (2018-08-23)
-- Add admin notification to alert users to update wp-config with Region constant
+1.6 (2018-08-29)
+- Refactor admin notifications to handle multisite installs
+- Enable settings page for WordPress install types
+- Enable Test Configuration for all WordPress install types
+- Test plugin up to WordPress 4.9.8
 
 1.5.13.1 (2018-08-15)
 - Fix line breaks in Test Configuration email

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Changelog
 =========
 
+1.5.13.2 (2018-08-23)
+- Add admin notification to alert users to update wp-config with Region constant
 
 1.5.13.1 (2018-08-15)
 - Fix line breaks in Test Configuration email

--- a/includes/lists-page.php
+++ b/includes/lists-page.php
@@ -23,8 +23,8 @@ global $mailgun;
 
 // check mailgun domain & api key
 $missing_error = '';
-$api_key = $this->get_option('apiKey');
-$mailgun_domain = $this->get_option('domain');
+$api_key = MAILGUN_APIKEY || $this->get_option('apiKey');
+$mailgun_domain = MAILGUN_DOMAIN || $this->get_option('domain');
 if ($api_key != '') {
     if ($mailgun_domain == '') {
         $missing_error = '<strong style="color:red;">Missing or invalid Mailgun Domain</strong>. ';
@@ -74,7 +74,7 @@ $lists_arr = $mailgun->get_lists();
                         <td><?php echo $list['address']; ?></td>
                         <td><?php echo $list['description']; ?></td>
                         <td>
-                            [mailgun id="<?php echo $list['address']; ?>"]
+							[mailgun id="<?php echo $list['address']; ?>"]
                         </td>
                     </tr>
 
@@ -85,8 +85,8 @@ $lists_arr = $mailgun->get_lists();
             <h3>Multi-list subscription</h3>
             <p>
                 <?php _e('To allow users to subscribe to multiple lists on a single form, comma-separate the Mailgun list ids.', 'mailgun'); ?></p>
-            <p class="description">
-                <?php _e('<strong>Example:</strong> [mailgun id="list1@mydomain.com,list2@mydomain.com"]'); ?>
+            <p>
+                <?php _e('<strong>Example:</strong> <code>[mailgun id="list1@mydomain.com,list2@mydomain.com"]</code>'); ?>
             </p>
 
         <?php endif; ?>

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -22,39 +22,33 @@
 ?>
         <div class="wrap">
             <div id="icon-options-general" class="icon32"><br /></div>
-            <span class="alignright"><a target="_blank" href="http://www.mailgun.com/"><img src="https://assets.mailgun.com/img/mailgun.svg" alt="Mailgun" style="width: 10em;"/></a></span>
+            <span class="alignright">
+				<a target="_blank" href="http://www.mailgun.com/">
+					<img src="https://assets.mailgun.com/img/mailgun.svg" alt="Mailgun" style="width:10em;"/>
+				</a>
+			</span>
             <h2><?php _e('Mailgun', 'mailgun'); ?></h2>
-            <p>A <a target="_blank" href="http://www.mailgun.com/">Mailgun</a> account is required to use this plugin and the Mailgun service.</p>
-            <p>If you need to register for an account, you can do so at <a target="_blank" href="http://www.mailgun.com/">http://www.mailgun.com/</a>.</p>
+			<p><?php _e('A <a target="_blank" href="http://www.mailgun.com/">Mailgun</a> account is required to use this plugin and the Mailgun service.', 'mailgun'); ?></p>
+			<p><?php _e('If you need to register for an account, you can do so at <a target="_blank" href="http://www.mailgun.com/">http://www.mailgun.com/</a>.', 'mailgun'); ?></p>
+
+			<h3><?php _e('Configuration', 'mailgun'); ?></h3>
+			<?php
+				$isMultisite = defined('WP_ALLOW_MULTISITE');
+				if( !$isMultisite ):
+			?>
             <form id="mailgun-form" action="options.php" method="post">
                 <?php settings_fields('mailgun'); ?>
-                <h3><?php _e('Configuration', 'mailgun'); ?></h3>
                 <table class="form-table">
 					<tr valign="top">
 						<th scope="row">
-			                <?php
-				                $config_region = (defined('MAILGUN_REGION') && MAILGUN_REGION);
-				                if ($config_region):
-					                _e('Your Region is', 'mailgun');
-				                else:
-					                _e('Select Your Region', 'mailgun');
-				                endif;
-			                ?>
+			                <?php _e('Select Your Region', 'mailgun'); ?>
 						</th>
 						<td>
-			                <?php
-				                if ($config_region):
-					                $region = (MAILGUN_REGION === 'us') ? __('U.S./North America', 'mailgun') : __('Europe', 'mailgun');
-					                ?>
-									<input readonly="readonly" id="mailgun-region" type="text" name="mailgun[region]" value="<?php echo $region ?>">
-									<p class="description"><?php _e('You have set the region in your wp-config.php file. Email will be sent from this region, and your customer data will be stored in this region.', 'mailgun') ?></p>
-				                <?php else: ?>
-									<select id="mailgun-region" name="mailgun[region]">
-										<option value="us"<?php selected('us', $this->get_option('region')); ?>><?php _e('U.S./North America', 'mailgun') ?></option>
-										<option value="eu"<?php selected('eu', $this->get_option('region')); ?>><?php _e('Europe', 'mailgun') ?></option>
-									</select>
-									<p class="description"><?php _e('Choose a region - U.S./North America or Europe - from which to send email, and to store your customer data. Please note that your sending domain must be set up in whichever region you choose.', 'mailgun') ?></p>
-				                <?php endif; ?>
+							<select id="mailgun-region" name="mailgun[region]">
+								<option value="us"<?php selected('us', $this->get_option('region')); ?>><?php _e('U.S./North America', 'mailgun') ?></option>
+								<option value="eu"<?php selected('eu', $this->get_option('region')); ?>><?php _e('Europe', 'mailgun') ?></option>
+							</select>
+							<p class="description"><?php _e('Choose a region - U.S./North America or Europe - from which to send email, and to store your customer data. Please note that your sending domain must be set up in whichever region you choose.', 'mailgun') ?></p>
 						</td>
 					</tr>
                     <tr valign="top">
@@ -194,7 +188,26 @@
                         </td>
                     </tr>
                 </table>
-                <h3><?php _e('Lists', 'mailgun'); ?></h3>
+
+			<?php else: ?>
+				<p><?php _e('Once you have configured the plugin settings in your wp-config.php, you can test it here.', 'mailgun'); ?></p>
+				<p><?php _e('The definitions are as follows:', 'mailgun'); ?></p>
+				<p><pre>
+MAILGUN_REGION       Choices: 'us' or 'eu'
+    ex. define('MAILGUN_REGION', 'us');
+MAILGUN_USEAPI
+MAILGUN_APIKEY
+MAILGUN_DOMAIN
+MAILGUN_USERNAME
+MAILGUN_PASSWORD
+MAILGUN_SECURE
+MAILGUN_SECTYPE       Choices: 'ssl' or 'tls'
+MAILGUN_FROM_NAME
+MAILGUN_FROM_ADDRESS
+				</pre></p>
+			<?php endif; ?>
+
+				<h3><?php _e('Lists', 'mailgun'); ?></h3>
                 <table class="form-table">
                     <tr valign="top">
                         <th scope="row">
@@ -202,7 +215,7 @@
                         </th>
                         <td>
                             <div>
-                                <strong>[mailgun id="<em>{mailgun list id}</em>" collect_name="true"]</strong>
+								<code>[mailgun id="<em>{mailgun list id}</em>" collect_name="true"]</code>
                             </div>
                             <div>
                                 <p class="description"><?php _e('Use the shortcode above to associate a widget instance with a mailgun list', 'mailgun'); ?></p>
@@ -214,15 +227,21 @@
                             <?php _e('Lists', 'mailgun'); ?>
                         </th>
                         <td>
-                            <a href="?page=mailgun-lists">View available lists</a>
+                            <?php _e('<a href="?page=mailgun-lists">View available lists</a>', 'mailgun'); ?>
                         </td>
                     </tr>
                 </table>
 
+            <?php if( !$isMultisite ): ?>
                 <p><?php _e('Before attempting to test the configuration, please click "Save Changes".', 'mailgun'); ?></p>
                 <p class="submit">
                     <input type="submit" class="button-primary" value="<?php _e('Save Changes', 'mailgun'); ?>" />
                     <input type="button" id="mailgun-test" class="button-secondary" value="<?php _e('Test Configuration', 'mailgun'); ?>" />
                 </p>
+			<?php else: ?>
+				<p class="submit">
+					<input type="button" id="mailgun-test" class="button-secondary" value="<?php _e('Test Configuration', 'mailgun'); ?>" />
+				</p>
+			<?php endif; ?>
             </form>
         </div>

--- a/languages/mailgun-template.po
+++ b/languages/mailgun-template.po
@@ -61,10 +61,6 @@ msgstr ""
 msgid "Mailgun is almost ready. "
 msgstr ""
 
-#: includes/admin.php:301
-msgid "You must <a href=\"%1$s\">configure Mailgun</a> for it to work."
-msgstr ""
-
 #: includes/admin.php:309
 msgid ""
 "\"Override From\" option requires that \"From Name\" and \"From Address\" be "

--- a/mailgun.php
+++ b/mailgun.php
@@ -4,7 +4,7 @@
  * Plugin Name:  Mailgun
  * Plugin URI:   http://wordpress.org/extend/plugins/mailgun/
  * Description:  Mailgun integration for WordPress
- * Version:      1.5.13.2
+ * Version:      1.6
  * Author:       Mailgun
  * Author URI:   http://www.mailgun.com/
  * License:      GPLv2 or later

--- a/mailgun.php
+++ b/mailgun.php
@@ -4,7 +4,7 @@
  * Plugin Name:  Mailgun
  * Plugin URI:   http://wordpress.org/extend/plugins/mailgun/
  * Description:  Mailgun integration for WordPress
- * Version:      1.5.13.1
+ * Version:      1.5.13.2
  * Author:       Mailgun
  * Author URI:   http://www.mailgun.com/
  * License:      GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Contributors: Mailgun, sivel, lookahead.io, m35dev
 Tags: mailgun, smtp, http, api, mail, email
 Requires at least: 3.3
 Tested up to: 4.9.8
-Stable tag: 1.5.13.1
+Stable tag: 1.6
 License: GPLv2 or later
 
 
@@ -128,8 +128,11 @@ MAILGUN_FROM_ADDRESS Type: string
 
 == Changelog ==
 
-= 1.5.13.2 (2018-08-23): =
-- Add admin notification to alert users to update wp-config with Region constant
+= 1.6 (2018-08-29): =
+- Refactor admin notifications to handle multisite installs
+- Enable settings page for WordPress install types
+- Enable Test Configuration for all WordPress install types
+- Test plugin up to WordPress 4.9.8
 
 = 1.5.13.1 (2018-08-15): =
 - Fix line breaks in Test Configuration email

--- a/readme.txt
+++ b/readme.txt
@@ -128,7 +128,10 @@ MAILGUN_FROM_ADDRESS Type: string
 
 == Changelog ==
 
-= 1.5.13.1 (2018-08-15)
+= 1.5.13.2 (2018-08-23): =
+- Add admin notification to alert users to update wp-config with Region constant
+
+= 1.5.13.1 (2018-08-15): =
 - Fix line breaks in Test Configuration email
 
 = 1.5.13 (2018-08-14): =


### PR DESCRIPTION
Minor refactoring to admin notifications to handle multisite WordPress installs.
1) Enable the settings page for all install types
2) Enable Test Configuration for all install types
3) Condense notifications displayed to user

@pirogoeth Review this with some care. I've tested in the docker environment, using the Settings page and also the constants in wp-config (though, not a real multisite environment). If you have questions, please ask.