### PR TITLE
Refactor admin notifications and settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 Changelog
 =========
 
-1.5.14 (2018-09-11):
+1.6 (2018-9-21)
+- Refactor admin notifications
+- Enable Settings page for all WordPress install types
+- Enable Test Configuration for all WordPress install types
+- Test plugin up to WordPress 4.9.8.
+
+1.5.14 (2018-09-11)
 - Force SSL-secured SMTP connections to use port 465 (SMTPS) to connect, 587 for plain and TLS
 - Support region endpoint switching for SMTP
 

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -1,477 +1,484 @@
 <?php
 
-/*
- * mailgun-wordpress-plugin - Sending mail from Wordpress using Mailgun
- * Copyright (C) 2016 Mailgun, et al.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- */
+	/*
+	 * mailgun-wordpress-plugin - Sending mail from Wordpress using Mailgun
+	 * Copyright (C) 2016 Mailgun, et al.
+	 *
+	 * This program is free software; you can redistribute it and/or modify
+	 * it under the terms of the GNU General Public License as published by
+	 * the Free Software Foundation; either version 2 of the License, or
+	 * (at your option) any later version.
+	 *
+	 * This program is distributed in the hope that it will be useful,
+	 * but WITHOUT ANY WARRANTY; without even the implied warranty of
+	 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	 * GNU General Public License for more details.
+	 *
+	 * You should have received a copy of the GNU General Public License along
+	 * with this program; if not, write to the Free Software Foundation, Inc.,
+	 * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+	 */
 
-class MailgunAdmin extends Mailgun
-{
-    /**
-     * @var	array	Array of "safe" option defaults.
-     */
-    private $defaults;
+	class MailgunAdmin extends Mailgun
+	{
+		/**
+		 * @var    array    Array of "safe" option defaults.
+		 */
+		private $defaults;
 
-    /**
-     * Setup backend functionality in WordPress.
-     *
-     * @return	void
-     *
-     * @since	0.1
-     */
-    public function __construct()
-    {
-        Mailgun::__construct();
+		/**
+		 * Setup backend functionality in WordPress.
+		 *
+		 * @return    void
+		 *
+		 * @since    0.1
+		 */
+		public function __construct()
+		{
+			Mailgun::__construct();
 
-        // Load localizations if available
-        load_plugin_textdomain('mailgun', false, 'mailgun/languages');
+			// Load localizations if available
+			load_plugin_textdomain('mailgun', false, 'mailgun/languages');
 
-        // Activation hook
-        register_activation_hook($this->plugin_file, array(&$this, 'init'));
+			// Activation hook
+			register_activation_hook($this->plugin_file, array(&$this, 'init'));
 
-		// Hook into admin_init and register settings and potentially register an admin_notice
-		add_action('admin_init', array(&$this, 'admin_init'));
+			// Hook into admin_init and register settings and potentially register an admin_notice
+			add_action('admin_init', array(&$this, 'admin_init'));
 
-		// Activate the options page
-		add_action('admin_menu', array(&$this, 'admin_menu'));
+			// Activate the options page
+			add_action('admin_menu', array(&$this, 'admin_menu'));
 
-        // Register an AJAX action for testing mail sending capabilities
-        add_action('wp_ajax_mailgun-test', array(&$this, 'ajax_send_test'));
-    }
+			// Register an AJAX action for testing mail sending capabilities
+			add_action('wp_ajax_mailgun-test', array(&$this, 'ajax_send_test'));
+		}
 
-    /**
-     * Initialize the default options during plugin activation.
-     *
-     * @return	void
-     *
-     * @since	0.1
-     */
-    public function init()
-    {
-        $sitename = strtolower($_SERVER['SERVER_NAME']);
-        if (substr($sitename, 0, 4) == 'www.'):
-            $sitename = substr($sitename, 4);
-        endif;
+		/**
+		 * Initialize the default options during plugin activation.
+		 *
+		 * @return    void
+		 *
+		 * @since    0.1
+		 */
+		public function init()
+		{
+			$sitename = strtolower($_SERVER[ 'SERVER_NAME' ]);
+			if (substr($sitename, 0, 4) == 'www.'):
+				$sitename = substr($sitename, 4);
+			endif;
 
-        $region = (defined('MAILGUN_REGION') && MAILGUN_REGION) ? MAILGUN_REGION : $this->get_option('region');
-		$regionDefault = $region ?: 'us';
+			$region = (defined('MAILGUN_REGION') && MAILGUN_REGION) ? MAILGUN_REGION : $this->get_option('region');
+			$regionDefault = $region ?: 'us';
 
-        $this->defaults = array(
-			'region'			=> $regionDefault,
-            'useAPI'            => '1',
-            'apiKey'            => '',
-            'domain'            => '',
-            'username'          => '',
-            'password'          => '',
-            'secure'            => '1',
-            'sectype'           => 'tls',
-            'track-clicks'      => '',
-            'track-opens'       => '',
-            'campaign-id'       => '',
-            'override-from'     => '0',
-            'tag'               => $sitename,
-        );
-        if (!$this->options):
-            $this->options = $this->defaults;
-            add_option('mailgun', $this->options);
-        endif;
-    }
+			$this->defaults = array(
+				'region' => $regionDefault,
+				'useAPI' => '1',
+				'apiKey' => '',
+				'domain' => '',
+				'username' => '',
+				'password' => '',
+				'secure' => '1',
+				'sectype' => 'tls',
+				'track-clicks' => '',
+				'track-opens' => '',
+				'campaign-id' => '',
+				'override-from' => '0',
+				'tag' => $sitename,
+			);
+			if (!$this->options):
+				$this->options = $this->defaults;
+				add_option('mailgun', $this->options);
+			endif;
+		}
 
-    /**
-     * Add the options page.
-     *
-     * @return	void
-     *
-     * @since	0.1
-     */
-    public function admin_menu()
-    {
-        if (current_user_can('manage_options')):
-            $this->hook_suffix = add_options_page(__('Mailgun', 'mailgun'), __('Mailgun', 'mailgun'), 'manage_options', 'mailgun', array(&$this, 'options_page'));
-            add_options_page(__('Mailgun Lists', 'mailgun'), __('Mailgun Lists', 'mailgun'), 'manage_options', 'mailgun-lists', array(&$this, 'lists_page'));
-            add_action("admin_print_scripts-{$this->hook_suffix}", array(&$this, 'admin_js'));
-            add_filter("plugin_action_links_{$this->plugin_basename}", array(&$this, 'filter_plugin_actions'));
-            add_action("admin_footer-{$this->hook_suffix}", array(&$this, 'admin_footer_js'));
-        endif;
-    }
+		/**
+		 * Add the options page.
+		 *
+		 * @return    void
+		 *
+		 * @since    0.1
+		 */
+		public function admin_menu()
+		{
+			if (current_user_can('manage_options')):
+				$this->hook_suffix = add_options_page(__('Mailgun', 'mailgun'), __('Mailgun', 'mailgun'),
+					'manage_options', 'mailgun', array(&$this, 'options_page'));
+				add_options_page(__('Mailgun Lists', 'mailgun'), __('Mailgun Lists', 'mailgun'), 'manage_options',
+					'mailgun-lists', array(&$this, 'lists_page'));
+				add_action("admin_print_scripts-{$this->hook_suffix}", array(&$this, 'admin_js'));
+				add_filter("plugin_action_links_{$this->plugin_basename}", array(&$this, 'filter_plugin_actions'));
+				add_action("admin_footer-{$this->hook_suffix}", array(&$this, 'admin_footer_js'));
+			endif;
+		}
 
-    /**
-     * Enqueue javascript required for the admin settings page.
-     *
-     * @return	void
-     *
-     * @since	0.1
-     */
-    public function admin_js()
-    {
-        wp_enqueue_script('jquery');
-    }
+		/**
+		 * Enqueue javascript required for the admin settings page.
+		 *
+		 * @return    void
+		 *
+		 * @since    0.1
+		 */
+		public function admin_js()
+		{
+			wp_enqueue_script('jquery');
+		}
 
-    /**
-     * Output JS to footer for enhanced admin page functionality.
-     *
-     * @since	0.1
-     */
-    public function admin_footer_js()
-    {
-        ?>
-        <script type="text/javascript">
-        /* <![CDATA[ */
-            var mailgunApiOrNot = function() {
-                if (jQuery("#mailgun-api").val() == 1) {
-                    jQuery(".mailgun-smtp").hide();
-                    jQuery(".mailgun-api").show();
+		/**
+		 * Output JS to footer for enhanced admin page functionality.
+		 *
+		 * @since    0.1
+		 */
+		public function admin_footer_js()
+		{
+			?>
+			<script type="text/javascript">
+              /* <![CDATA[ */
+              var mailgunApiOrNot = function () {
+                if (jQuery('#mailgun-api').val() == 1) {
+                  jQuery('.mailgun-smtp').hide()
+                  jQuery('.mailgun-api').show()
                 } else {
-                    jQuery(".mailgun-api").hide();
-                    jQuery(".mailgun-smtp").show();
+                  jQuery('.mailgun-api').hide()
+                  jQuery('.mailgun-smtp').show()
                 }
 
-            }
-            var formModified = false;
-            jQuery().ready(function() {
-                mailgunApiOrNot();
-                jQuery('#mailgun-api').change(function() {
-                    mailgunApiOrNot();
-                });
-                jQuery('#mailgun-test').click(function(e) {
-                    e.preventDefault();
-                    if ( formModified ) {
-                        var doTest = confirm('<?php _e('The Mailgun plugin configuration has changed since you last saved. Do you wish to test anyway?\n\nClick "Cancel" and then "Save Changes" if you wish to save your changes.', 'mailgun'); ?>');
-                        if ( ! doTest ) {
-                            return false;
-                        }
+              }
+              var formModified = false
+              jQuery().ready(function () {
+                mailgunApiOrNot()
+                jQuery('#mailgun-api').change(function () {
+                  mailgunApiOrNot()
+                })
+                jQuery('#mailgun-test').click(function (e) {
+                  e.preventDefault()
+                  if (formModified) {
+                    var doTest = confirm('<?php _e('The Mailgun plugin configuration has changed since you last saved. Do you wish to test anyway?\n\nClick "Cancel" and then "Save Changes" if you wish to save your changes.',
+						'mailgun'); ?>')
+                    if (!doTest) {
+                      return false
                     }
-                    jQuery(this).val('<?php _e('Testing...', 'mailgun'); ?>');
-                    jQuery("#mailgun-test-result").text('');
-                    jQuery.get(
-                        ajaxurl,
-                        {
-                            action: 'mailgun-test',
-                            _wpnonce: '<?php echo wp_create_nonce(); ?>'
-                        }
-                    )
-                    .complete(function() {
-                        jQuery("#mailgun-test").val('<?php _e('Test Configuration', 'mailgun'); ?>');
+                  }
+                  jQuery(this).val('<?php _e('Testing...', 'mailgun'); ?>')
+                  jQuery('#mailgun-test-result').text('')
+                  jQuery.get(
+                    ajaxurl,
+                    {
+                      action: 'mailgun-test',
+                      _wpnonce: '<?php echo wp_create_nonce(); ?>'
+                    }
+                  )
+                    .complete(function () {
+                      jQuery('#mailgun-test').val('<?php _e('Test Configuration', 'mailgun'); ?>')
                     })
-                    .success(function(data) {
-                        alert(
-                            'Mailgun ' + data.method + ' Test ' + data.message
-                            + '; status "' + data.error + '"'
-                        );
+                    .success(function (data) {
+                      alert(
+                        'Mailgun ' + data.method + ' Test ' + data.message
+                        + '; status "' + data.error + '"'
+                      )
                     })
-                    .error(function() {
-                        alert('Mailgun Test <?php _e('Failure', 'mailgun'); ?>');
-                    });
-                });
-                jQuery("#mailgun-form").change(function() {
-                    formModified = true;
-                });
-            });
-        /* ]]> */
-        </script>
-        <?php
+                    .error(function () {
+                      alert('Mailgun Test <?php _e('Failure', 'mailgun'); ?>')
+                    })
+                })
+                jQuery('#mailgun-form').change(function () {
+                  formModified = true
+                })
+              })
+              /* ]]> */
+			</script>
+			<?php
 
-    }
+		}
 
-    /**
-     * Output the options page.
-     *
-     * @return	void
-     *
-     * @since	0.1
-     */
-    public function options_page()
-    {
-        if (!@include 'options-page.php'):
-            printf(__('<div id="message" class="updated fade"><p>The options page for the <strong>Mailgun</strong> plugin cannot be displayed. The file <strong>%s</strong> is missing.  Please reinstall the plugin.</p></div>', 'mailgun'), dirname(__FILE__).'/options-page.php');
-        endif;
-    }
+		/**
+		 * Output the options page.
+		 *
+		 * @return    void
+		 *
+		 * @since    0.1
+		 */
+		public function options_page()
+		{
+			if (!@include 'options-page.php'):
+				printf(__('<div id="message" class="updated fade"><p>The options page for the <strong>Mailgun</strong> plugin cannot be displayed. The file <strong>%s</strong> is missing.  Please reinstall the plugin.</p></div>',
+					'mailgun'), dirname(__FILE__) . '/options-page.php');
+			endif;
+		}
 
-    /**
-     * Output the lists page.
-     *
-     * @return	void
-     *
-     * @since	0.1
-     */
-    public function lists_page()
-    {
-        if (!@include 'lists-page.php'):
-            printf(__('<div id="message" class="updated fade"><p>The lists page for the <strong>Mailgun</strong> plugin cannot be displayed. The file <strong>%s</strong> is missing.  Please reinstall the plugin.</p></div>', 'mailgun'), dirname(__FILE__).'/lists-page.php');
-        endif;
-    }
+		/**
+		 * Output the lists page.
+		 *
+		 * @return    void
+		 *
+		 * @since    0.1
+		 */
+		public function lists_page()
+		{
+			if (!@include 'lists-page.php'):
+				printf(__('<div id="message" class="updated fade"><p>The lists page for the <strong>Mailgun</strong> plugin cannot be displayed. The file <strong>%s</strong> is missing.  Please reinstall the plugin.</p></div>',
+					'mailgun'), dirname(__FILE__) . '/lists-page.php');
+			endif;
+		}
 
-    /**
-     * Wrapper function hooked into admin_init to register settings
-     * and potentially register an admin notice if the plugin hasn't
-     * been configured yet.
-     *
-     * @return	void
-     *
-     * @since	0.1
-     */
-    public function admin_init()
-    {
-        $this->register_settings();
-		$region = $this->get_option('region');
-        $apiKey = $this->get_option('apiKey');
-        $useAPI = $this->get_option('useAPI');
-        $password = $this->get_option('password');
+		/**
+		 * Wrapper function hooked into admin_init to register settings
+		 * and potentially register an admin notice if the plugin hasn't
+		 * been configured yet.
+		 *
+		 * @return    void
+		 *
+		 * @since    0.1
+		 */
+		public function admin_init()
+		{
+			$this->register_settings();
+			$region = $this->get_option('region');
+			$apiKey = $this->get_option('apiKey');
+			$useAPI = $this->get_option('useAPI');
+			$password = $this->get_option('password');
 
-        add_action('admin_notices', array(&$this, 'admin_notices'));
-    }
+			add_action('admin_notices', array(&$this, 'admin_notices'));
+		}
 
-    /**
-     * Whitelist the mailgun options.
-     *
-	 * @return	void
-	 *
-     * @since	0.1
-     */
-    public function register_settings()
-    {
-        register_setting('mailgun', 'mailgun', array(&$this, 'validation'));
-    }
+		/**
+		 * Whitelist the mailgun options.
+		 *
+		 * @return    void
+		 *
+		 * @since    0.1
+		 */
+		public function register_settings()
+		{
+			register_setting('mailgun', 'mailgun', array(&$this, 'validation'));
+		}
 
-    /**
-     * Data validation callback function for options.
-     *
-     * @param	array	$options	An array of options posted from the options page
-     *
-     * @return	array
-     *
-     * @since	0.1
-     */
-    public function validation($options)
-    {
-        $apiKey = trim($options['apiKey']);
-        $username = trim($options['username']);
-        if (!empty($apiKey)):
-            $pos = strpos($apiKey, 'api:');
-            if ($pos !== false && $pos == 0):
-                $apiKey = substr($apiKey, 4);
-            endif;
+		/**
+		 * Data validation callback function for options.
+		 *
+		 * @param    array $options An array of options posted from the options page
+		 *
+		 * @return    array
+		 *
+		 * @since    0.1
+		 */
+		public function validation($options)
+		{
+			$apiKey = trim($options[ 'apiKey' ]);
+			$username = trim($options[ 'username' ]);
+			if (!empty($apiKey)):
+				$pos = strpos($apiKey, 'api:');
+				if ($pos !== false && $pos == 0):
+					$apiKey = substr($apiKey, 4);
+				endif;
 
-            if (1 === preg_match('(\w{32}-\w{8}-\w{8})', $apiKey)):
-                $options['apiKey'] = $apiKey;
-            else:
-                $pos = strpos($apiKey, 'key-');
-                if ($pos === false || $pos > 4):
-                    $apiKey = "key-{$apiKey}";
-                endif;
+				if (1 === preg_match('(\w{32}-\w{8}-\w{8})', $apiKey)):
+					$options[ 'apiKey' ] = $apiKey;
+				else:
+					$pos = strpos($apiKey, 'key-');
+					if ($pos === false || $pos > 4):
+						$apiKey = "key-{$apiKey}";
+					endif;
 
-                $options['apiKey'] = $apiKey;
-            endif;
-        endif;
+					$options[ 'apiKey' ] = $apiKey;
+				endif;
+			endif;
 
-        if (!empty($username)):
-            $username = preg_replace('/@.+$/', '', $username);
-            $options['username'] = $username;
-        endif;
+			if (!empty($username)):
+				$username = preg_replace('/@.+$/', '', $username);
+				$options[ 'username' ] = $username;
+			endif;
 
-        foreach ($options as $key => $value) {
-            $options[$key] = trim($value);
-        }
+			foreach ($options as $key => $value) {
+				$options[ $key ] = trim($value);
+			}
 
-        if (empty($options['override-from'])):
-            $options['override-from'] = $this->defaults['override-from'];
-        endif;
+			if (empty($options[ 'override-from' ])):
+				$options[ 'override-from' ] = $this->defaults[ 'override-from' ];
+			endif;
 
-        if (empty($options['sectype'])):
-            $options['sectype'] = $this->defaults['sectype'];
-        endif;
+			if (empty($options[ 'sectype' ])):
+				$options[ 'sectype' ] = $this->defaults[ 'sectype' ];
+			endif;
 
-        $this->options = $options;
+			$this->options = $options;
 
-        return $options;
-    }
+			return $options;
+		}
 
-    /**
-     * Function to output an admin notice
-     * when plugin settings or constants need to be configured
-     *
-     * @return	void
-     *
-     * @since	0.1
-     */
-    public function admin_notices()
-    {
-        $screen = get_current_screen();
-        if (!current_user_can('manage_options') || $screen->id == $this->hook_suffix):
-            return;
-        endif;
+		/**
+		 * Function to output an admin notice
+		 * when plugin settings or constants need to be configured
+		 *
+		 * @return    void
+		 *
+		 * @since    0.1
+		 */
+		public function admin_notices()
+		{
+			$screen = get_current_screen();
+			if (!current_user_can('manage_options') || $screen->id == $this->hook_suffix):
+				return;
+			endif;
 
-        if (defined('WP_ALLOW_MULTISITE') && !defined('MAILGUN_REGION')
-			|| (!$this->get_option('apiKey') && $this->get_option('useAPI') === '1')
-            || (!$this->get_option('password') && $this->get_option('useAPI') === '0')
-			|| (!$this->get_option('region') && $this->get_option('useAPI') === '1')
-        ):
-?>
-			<div id='mailgun-warning' class='notice notice-warning is-dismissible'>
-                <p>
-                    <strong>
-                        <?php _e('Mailgun is almost ready. ', 'mailgun'); ?>
-                    </strong>
-	                <?php
-						printf(
-	                		__('With the latest update, Mailgun now supports multiple regions! By default, we will use the U.S. region, but we now have an EU region available. You can configure your Mailgun settings <a href="%1$s">here</a> or in your wp-config.php.', 'mailgun'),
-							menu_page_url('mailgun', false)
-	                	);
-	                ?>
-                </p>
-            </div>
-<?php
-		endif;
-
-        if ($this->get_option('override-from') === '1' &&
-			(!$this->get_option('from-name') || !$this->get_option('from-address'))
-        ):
-?>
-			<div id='mailgun-warning' class='notice notice-warning is-dismissible'>
-                <p>
-                    <strong>
-                        <?php _e('Mailgun is almost ready. ', 'mailgun'); ?>
-                    </strong>
-                    <?php
-						printf(
-								__('"Override From" option requires that "From Name" and "From Address" be set to work properly! <a href="%1$s">Configure Mailgun now</a>.', 'mailgun'),
+			if ((defined('WP_ALLOW_MULTISITE') && !defined('MAILGUN_REGION'))
+				|| (!$this->get_option('apiKey') && $this->get_option('useAPI') === '1')
+				|| (!$this->get_option('password') && $this->get_option('useAPI') === '0')
+				|| (!$this->get_option('region') && $this->get_option('useAPI') === '1')
+			):
+				?>
+				<div id='mailgun-warning' class='notice notice-warning is-dismissible'>
+					<p>
+						<strong>
+							<?php _e('Mailgun is almost ready. ', 'mailgun'); ?>
+						</strong>
+						<?php
+							printf(
+								__('With the latest update, Mailgun now supports multiple regions! By default, we will use the U.S. region, but we now have an EU region available. You can configure your Mailgun settings <a href="%1$s">here</a> or in your wp-config.php.',
+									'mailgun'),
 								menu_page_url('mailgun', false)
-						);
-					?>
-                </p>
-            </div>
-<?php
-		endif;
-    }
-
-    /**
-     * Add a settings link to the plugin actions.
-     *
-     * @param	array	$links	Array of the plugin action links
-     *
-     * @return	array
-     *
-     * @since	0.1
-     */
-    public function filter_plugin_actions($links)
-    {
-        $settings_link = '<a href="'.menu_page_url('mailgun', false).'">'.__('Settings', 'mailgun').'</a>';
-        array_unshift($links, $settings_link);
-
-        return $links;
-    }
-
-    /**
-     * AJAX callback function to test mail sending functionality.
-     *
-     * @return	string
-     *
-     * @since	0.1
-     */
-    public function ajax_send_test()
-    {
-        nocache_headers();
-        header('Content-Type: application/json');
-
-        if (!current_user_can('manage_options') || !wp_verify_nonce($_GET['_wpnonce'])):
-            die(
-                json_encode(
-                    array(
-                        'message' => __('Unauthorized', 'mailgun'),
-                        'method'  => null,
-                        'error'   => __('Unauthorized', 'mailgun'),
-                    )
-                )
-            );
-        endif;
-
-		$getRegion = (defined('MAILGUN_REGION') && MAILGUN_REGION) ? MAILGUN_REGION : $this->get_option('region');
-        $useAPI = (defined('MAILGUN_USEAPI') && MAILGUN_USEAPI) ? MAILGUN_USEAPI : $this->get_option('useAPI');
-        $secure = (defined('MAILGUN_SECURE') && MAILGUN_SECURE) ? MAILGUN_SECURE : $this->get_option('secure');
-        $sectype = (defined('MAILGUN_SECTYPE') && MAILGUN_SECTYPE) ? MAILGUN_SECTYPE : $this->get_option('sectype');
-
-        if ((bool) !$getRegion):
-			mg_api_last_error(__("Region has not been selected", "mailgun"));
-		else:
-
-			if ($getRegion === 'us'):
-				$region = __("U.S./North America", "mailgun");
+							);
+						?>
+					</p>
+				</div>
+			<?php
 			endif;
 
-			if ($getRegion === "eu"):
-				$region = __("Europe", "mailgun");
+			if ($this->get_option('override-from') === '1' &&
+				(!$this->get_option('from-name') || !$this->get_option('from-address'))
+			):
+				?>
+				<div id='mailgun-warning' class='notice notice-warning is-dismissible'>
+					<p>
+						<strong>
+							<?php _e('Mailgun is almost ready. ', 'mailgun'); ?>
+						</strong>
+						<?php
+							printf(
+								__('"Override From" option requires that "From Name" and "From Address" be set to work properly! <a href="%1$s">Configure Mailgun now</a>.',
+									'mailgun'),
+								menu_page_url('mailgun', false)
+							);
+						?>
+					</p>
+				</div>
+			<?php
 			endif;
-		endif;
+		}
 
-        if ((bool) $useAPI):
-            $method = __('HTTP API', 'mailgun');
-        else:
-            $method = ((bool) $secure) ? __('Secure SMTP', 'mailgun') : __('Insecure SMTP', 'mailgun');
-            if ((bool) $secure):
-                $method = $method . sprintf(__(' via %s', 'mailgun'), $sectype);
-            endif;
-        endif;
+		/**
+		 * Add a settings link to the plugin actions.
+		 *
+		 * @param    array $links Array of the plugin action links
+		 *
+		 * @return    array
+		 *
+		 * @since    0.1
+		 */
+		public function filter_plugin_actions($links)
+		{
+			$settings_link = '<a href="' . menu_page_url('mailgun', false) . '">' . __('Settings', 'mailgun') . '</a>';
+			array_unshift($links, $settings_link);
 
-        $admin_email = get_option('admin_email');
-        $result = wp_mail(
-            $admin_email,
-            __('Mailgun WordPress Plugin Test', 'mailgun'),
-            sprintf(__("This is a test email generated by the Mailgun WordPress plugin.\n\nIf you have received this message, the requested test has succeeded.\n\nThe sending region is set to %s.\n\nThe method used to send this email was: %s.", 'mailgun'), $region, $method),
-            array('Content-Type: text/plain')
-        );
+			return $links;
+		}
 
-        if ((bool) $useAPI):
-            if (!function_exists('mg_api_last_error')):
-                if (!include dirname(__FILE__).'/wp-mail-api.php'):
-                    self::deactivate_and_die(dirname(__FILE__).'/wp-mail-api.php');
-                endif;
-            endif;
+		/**
+		 * AJAX callback function to test mail sending functionality.
+		 *
+		 * @return    string
+		 *
+		 * @since    0.1
+		 */
+		public function ajax_send_test()
+		{
+			nocache_headers();
+			header('Content-Type: application/json');
 
-            $error_msg = mg_api_last_error();
-        else:
-            if (!function_exists('mg_smtp_last_error')):
-                if (!include dirname(__FILE__).'/wp-mail-smtp.php'):
-                    self::deactivate_and_die(dirname(__FILE__).'/wp-mail-smtp.php');
-                endif;
-            endif;
+			if (!current_user_can('manage_options') || !wp_verify_nonce($_GET[ '_wpnonce' ])):
+				die(
+				json_encode(
+					array(
+						'message' => __('Unauthorized', 'mailgun'),
+						'method' => null,
+						'error' => __('Unauthorized', 'mailgun'),
+					)
+				)
+				);
+			endif;
 
-            $error_msg = mg_smtp_last_error();
-        endif;
+			$getRegion = (defined('MAILGUN_REGION') && MAILGUN_REGION) ? MAILGUN_REGION : $this->get_option('region');
+			$useAPI = (defined('MAILGUN_USEAPI') && MAILGUN_USEAPI) ? MAILGUN_USEAPI : $this->get_option('useAPI');
+			$secure = (defined('MAILGUN_SECURE') && MAILGUN_SECURE) ? MAILGUN_SECURE : $this->get_option('secure');
+			$sectype = (defined('MAILGUN_SECTYPE') && MAILGUN_SECTYPE) ? MAILGUN_SECTYPE : $this->get_option('sectype');
 
-        if ($result):
-            die(
-                json_encode(
-                    array(
-                        'message' => __('Success', 'mailgun'),
-                        'method'  => $method,
-                        'error'   => __('Success', 'mailgun'),
-                    )
-                )
-            );
-        else:
-            die(
-                json_encode(
-                    array(
-                        'message' => __('Failure', 'mailgun'),
-                        'method'  => $method,
-                        'error'   => $error_msg,
-                    )
-                )
-            );
-        endif;
-    }
-}
+			if ((bool) !$getRegion):
+				mg_api_last_error(__("Region has not been selected", "mailgun"));
+			else:
+				if ($getRegion === 'us'):
+					$region = __("U.S./North America", "mailgun");
+				endif;
+
+				if ($getRegion === "eu"):
+					$region = __("Europe", "mailgun");
+				endif;
+			endif;
+
+			if ((bool) $useAPI):
+				$method = __('HTTP API', 'mailgun');
+			else:
+				$method = ((bool) $secure) ? __('Secure SMTP', 'mailgun') : __('Insecure SMTP', 'mailgun');
+				if ((bool) $secure):
+					$method = $method . sprintf(__(' via %s', 'mailgun'), $sectype);
+				endif;
+			endif;
+
+			$admin_email = get_option('admin_email');
+			$result = wp_mail(
+				$admin_email,
+				__('Mailgun WordPress Plugin Test', 'mailgun'),
+				sprintf(__("This is a test email generated by the Mailgun WordPress plugin.\n\nIf you have received this message, the requested test has succeeded.\n\nThe sending region is set to %s.\n\nThe method used to send this email was: %s.",
+					'mailgun'), $region, $method),
+				array('Content-Type: text/plain')
+			);
+
+			if ((bool) $useAPI):
+				if (!function_exists('mg_api_last_error')):
+					if (!include dirname(__FILE__) . '/wp-mail-api.php'):
+						self::deactivate_and_die(dirname(__FILE__) . '/wp-mail-api.php');
+					endif;
+				endif;
+
+				$error_msg = mg_api_last_error();
+			else:
+				if (!function_exists('mg_smtp_last_error')):
+					if (!include dirname(__FILE__) . '/wp-mail-smtp.php'):
+						self::deactivate_and_die(dirname(__FILE__) . '/wp-mail-smtp.php');
+					endif;
+				endif;
+
+				$error_msg = mg_smtp_last_error();
+			endif;
+
+			if ($result):
+				die(
+				json_encode(
+					array(
+						'message' => __('Success', 'mailgun'),
+						'method' => $method,
+						'error' => __('Success', 'mailgun'),
+					)
+				)
+				);
+			else:
+				die(
+				json_encode(
+					array(
+						'message' => __('Failure', 'mailgun'),
+						'method' => $method,
+						'error' => $error_msg,
+					)
+				)
+				);
+			endif;
+		}
+	}

--- a/includes/lists-page.php
+++ b/includes/lists-page.php
@@ -23,15 +23,15 @@ global $mailgun;
 
 // check mailgun domain & api key
 $missing_error = '';
-$api_key = $this->get_option('apiKey');
-$mailgun_domain = $this->get_option('domain');
-if ($api_key != '') {
-    if ($mailgun_domain == '') {
+$api_key = (defined('MAILGUN_APIKEY') && MAILGUN_APIKEY) ? MAILGUN_APIKEY : $this->get_option('apiKey');
+$mailgun_domain = (defined('MAILGUN_DOMAIN') && MAILGUN_DOMAIN) ? MAILGUN_DOMAIN : $this->get_option('domain');
+if ($api_key != ''):
+    if ($mailgun_domain == ''):
         $missing_error = '<strong style="color:red;">Missing or invalid Mailgun Domain</strong>. ';
-    }
-} else {
+    endif;
+else:
     $missing_error = '<strong style="color:red;">Missing or invalid API Key</strong>. ';
-}
+endif;
 
 // import available lists
 $lists_arr = $mailgun->get_lists();
@@ -85,8 +85,8 @@ $lists_arr = $mailgun->get_lists();
             <h3>Multi-list subscription</h3>
             <p>
                 <?php _e('To allow users to subscribe to multiple lists on a single form, comma-separate the Mailgun list ids.', 'mailgun'); ?></p>
-            <p class="description">
-                <?php _e('<strong>Example:</strong> [mailgun id="list1@mydomain.com,list2@mydomain.com"]'); ?>
+            <p>
+                <?php _e('<strong>Example:</strong> <code>[mailgun id="list1@mydomain.com,list2@mydomain.com"]</code>'); ?>
             </p>
 
         <?php endif; ?>

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -1,273 +1,435 @@
 <?php
 
-/*
- * mailgun-wordpress-plugin - Sending mail from Wordpress using Mailgun
- * Copyright (C) 2016 Mailgun, et al.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- */
+	/*
+	 * mailgun-wordpress-plugin - Sending mail from Wordpress using Mailgun
+	 * Copyright (C) 2016 Mailgun, et al.
+	 *
+	 * This program is free software; you can redistribute it and/or modify
+	 * it under the terms of the GNU General Public License as published by
+	 * the Free Software Foundation; either version 2 of the License, or
+	 * (at your option) any later version.
+	 *
+	 * This program is distributed in the hope that it will be useful,
+	 * but WITHOUT ANY WARRANTY; without even the implied warranty of
+	 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	 * GNU General Public License for more details.
+	 *
+	 * You should have received a copy of the GNU General Public License along
+	 * with this program; if not, write to the Free Software Foundation, Inc.,
+	 * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+	 */
 
 ?>
-        <div class="wrap">
-            <div id="icon-options-general" class="icon32"><br /></div>
-            <span class="alignright">
+<div class="wrap">
+	<div id="icon-options-general" class="icon32"><br/></div>
+	<span class="alignright">
 				<a target="_blank" href="http://www.mailgun.com/">
 					<img src="https://assets.mailgun.com/img/mailgun.svg" alt="Mailgun" style="width:10em;"/>
 				</a>
 			</span>
-            <h2><?php _e('Mailgun', 'mailgun'); ?></h2>
-            <p>
+	<h2><?php _e('Mailgun', 'mailgun'); ?></h2>
+	<p>
+		<?php
+			$url = 'https://www.mailgun.com';
+			$link = sprintf(
+				wp_kses(
+					__('A <a href="%1$s" target="%2$s">Mailgun</a> account is required to use this plugin and the Mailgun service.', 'mailgun'),
+					array('a' => array(
+							'href' => array(),
+							'target' => array()
+						)
+					)
+				), esc_url($url), '_blank'
+			);
+			echo $link;
+		?>
+	</p>
+	<p>
+		<?php
+			$url = 'https://signup.mailgun.com/new/signup';
+			$link = sprintf(
+				wp_kses(
+					__('If you need to register for an account, you can do so at <a href="%1$s" target="%2$s">Mailgun.com</a>.', 'mailgun'),
+					array('a' => array(
+							'href' => array(),
+							'target' => array()
+						)
+					)
+				), esc_url($url), '_blank'
+			);
+			echo $link;
+		?>
+	</p>
+
+	<h3><?php _e('Configuration', 'mailgun'); ?></h3>
+
+	<?php
+		$isMultisite = defined('WP_ALLOW_MULTISITE');
+		if (!$isMultisite):
+	?>
+	<form id="mailgun-form" action="options.php" method="post">
+		<?php settings_fields('mailgun'); ?>
+
+		<table class="form-table">
+			<tr valign="top">
+				<th scope="row">
+					<?php _e('Select Your Region', 'mailgun'); ?>
+				</th>
+				<td>
+					<select id="mailgun-region" name="mailgun[region]">
+						<option value="us"<?php selected('us', $this->get_option('region')); ?>><?php _e('U.S./North America', 'mailgun') ?></option>
+						<option value="eu"<?php selected('eu', $this->get_option('region')); ?>><?php _e('Europe', 'mailgun') ?></option>
+					</select>
+					<p class="description">
+						<?php
+							_e('Choose a region - U.S./North America or Europe - from which to send email, and to store your customer data. Please note that your sending domain must be set up in whichever region you choose.', 'mailgun');
+						?>
+					</p>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row">
+					<?php _e('Use HTTP API', 'mailgun'); ?>
+				</th>
+				<td>
+					<select id="mailgun-api" name="mailgun[useAPI]">
+						<option value="1"<?php selected('1', $this->get_option('useAPI')); ?>><?php _e('Yes', 'mailgun'); ?></option>
+						<option value="0"<?php selected('0', $this->get_option('useAPI')); ?>><?php _e('No', 'mailgun'); ?></option>
+					</select>
+					<p class="description">
+						<?php
+							_e('Set this to "No" if your server cannot make outbound HTTP connections or if emails are not being delivered. "No" will cause this plugin to use SMTP. Default "Yes".', 'mailgun');
+						?>
+					</p>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row">
+					<?php _e('Mailgun Domain Name', 'mailgun'); ?>
+				</th>
+				<td>
+					<input type="text" class="regular-text"
+						   name="mailgun[domain]"
+						   value="<?php esc_attr_e($this->get_option('domain')); ?>"
+						   placeholder="samples.mailgun.org"
+					/>
+					<p class="description">
+						<?php _e('Your Mailgun Domain Name.', 'mailgun'); ?>
+					</p>
+				</td>
+			</tr>
+			<tr valign="top" class="mailgun-api">
+				<th scope="row">
+					<?php _e('API Key', 'mailgun'); ?>
+				</th>
+				<td>
+					<input type="text" class="regular-text" name="mailgun[apiKey]"
+						   value="<?php esc_attr_e($this->get_option('apiKey')); ?>"
+						   placeholder="key-3ax6xnjp29jd6fds4gc373sgvjxteol0"
+					/>
+					<p class="description">
+						<?php
+							_e('Your Mailgun API key. Only valid for use with the API.', 'mailgun');
+						?>
+					</p>
+				</td>
+			</tr>
+			<tr valign="top" class="mailgun-smtp">
+				<th scope="row">
+					<?php _e('Username', 'mailgun'); ?>
+				</th>
+				<td>
+					<input type="text" class="regular-text"
+						   name="mailgun[username]"
+						   value="<?php esc_attr_e($this->get_option('username')); ?>"
+						   placeholder="postmaster"
+					/>
+					<p class="description">
+						<?php
+							_e('Your Mailgun SMTP username. Only valid for use with SMTP.', 'mailgun');
+						?>
+					</p>
+				</td>
+			</tr>
+			<tr valign="top" class="mailgun-smtp">
+				<th scope="row">
+					<?php _e('Password', 'mailgun'); ?>
+				</th>
+				<td>
+					<input type="text" class="regular-text"
+						   name="mailgun[password]"
+						   value="<?php esc_attr_e($this->get_option('password')); ?>"
+						   placeholder="my-password"
+					/>
+					<p class="description">
+						<?php
+							_e('Your Mailgun SMTP password that goes with the above username. Only valid for use with SMTP.', 'mailgun');
+						?>
+					</p>
+				</td>
+			</tr>
+			<tr valign="top" class="mailgun-smtp">
+				<th scope="row">
+					<?php _e('Use Secure SMTP', 'mailgun'); ?>
+				</th>
+				<td>
+					<select name="mailgun[secure]">
+						<option value="1"<?php selected('1', $this->get_option('secure')); ?>><?php _e('Yes', 'mailgun'); ?></option>
+						<option value="0"<?php selected('0', $this->get_option('secure')); ?>><?php _e('No', 'mailgun'); ?></option>
+					</select>
+					<p class="description">
+						<?php
+							_e('Set this to "No" if your server cannot establish SSL SMTP connections or if emails are not being delivered. If you set this to "No" your password will be sent in plain text. Only valid for use with SMTP. Default "Yes".', 'mailgun');
+						?>
+					</p>
+				</td>
+			</tr>
+			<tr valign="top" class="mailgun-smtp">
+				<th scope="row">
+					<?php _e('Security Type', 'mailgun'); ?>
+				</th>
+				<td>
+					<select name="mailgun[sectype]">
+						<option value="ssl"<?php selected('ssl', $this->get_option('sectype')); ?>>SSL</option>
+						<option value="tls"<?php selected('tls', $this->get_option('sectype')); ?>>TLS</option>
+					</select>
+					<p class="description">
+						<?php
+							_e('Leave this at "TLS" unless mail sending fails. This option only matters for Secure SMTP. Default "TLS".', 'mailgun');
+						?>
+					</p>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row">
+					<?php _e('Click Tracking', 'mailgun'); ?>
+				</th>
+				<td>
+					<select name="mailgun[track-clicks]">
+						<option value="htmlonly"<?php selected('htmlonly', $this->get_option('track-clicks')); ?>><?php _e('HTML Only', 'mailgun'); ?></option>
+						<option value="yes"<?php selected('yes', $this->get_option('track-clicks')); ?>><?php _e('Yes', 'mailgun'); ?></option>
+						<option value="no"<?php selected('no', $this->get_option('track-clicks')); ?>><?php _e('No', 'mailgun'); ?></option>
+					</select>
+					<p class="description">
+						<?php
+							$url = 'http://documentation.mailgun.com/user_manual.html#tracking-clicks';
+							$link = sprintf(
+								wp_kses(
+									__('If enabled, Mailgun will and track links. <a href="%1$s" target="%2$s">Open Tracking Documentation</a>.', 'mailgun'),
+									array('a' => array(
+										'href' => array(),
+										'target' => array()
+										)
+									)
+								), esc_url($url), '_blank'
+							);
+							echo $link;
+						?>
+					</p>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row">
+					<?php _e('Open Tracking', 'mailgun'); ?>
+				</th>
+				<td>
+					<select name="mailgun[track-opens]">
+						<option value="1"<?php selected('1', $this->get_option('track-opens')); ?>><?php _e('Yes', 'mailgun'); ?></option>
+						<option value="0"<?php selected('0', $this->get_option('track-opens')); ?>><?php _e('No', 'mailgun'); ?></option>
+					</select>
+					<p class="description">
+						<?php
+							$url = 'http://documentation.mailgun.com/user_manual.html#tracking-opens';
+							$link = sprintf(
+								wp_kses(
+									__('If enabled, HTML messages will include an open tracking beacon. <a href="%1$s" target="%2$s">Open Tracking Documentation</a>.', 'mailgun'),
+									array('a' => array(
+										'href' => array(),
+										'target' => array()
+										)
+									)
+								), esc_url($url), '_blank'
+							);
+							echo $link;
+						?>
+					</p>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row">
+					<?php _e('From Address', 'mailgun'); ?>
+				</th>
+				<td>
+					<input type="text"
+						   class="regular-text"
+						   name="mailgun[from-address]"
+						   value="<?php esc_attr_e($this->get_option('from-address')); ?>"
+						   placeholder="wordpress@mydomain.com"
+					/>
+					<p class="description">
+						<?php
+							_e('The &lt;address@mydomain.com&gt; part of the sender information (<code>"Excited User &lt;user@samples.mailgun.org&gt;"</code>). This address will appear as the `From` address on sent mail. <strong>It is recommended that the @mydomain portion matches your Mailgun sending domain.</strong>', 'mailgun');
+						?>
+					</p>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row">
+					<?php _e('From Name', 'mailgun'); ?>
+				</th>
+				<td>
+					<input type="text" class="regular-text"
+						   name="mailgun[from-name]"
+						   value="<?php esc_attr_e($this->get_option('from-name')); ?>"
+						   placeholder="WordPress"
+					/>
+					<p class="description">
+						<?php
+							_e('The "User Name" part of the sender information (<code>"Excited User &lt;user@samples.mailgun.org&gt;"</code>).', 'mailgun');
+						?>
+					</p>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row">
+					<?php _e('Override "From" Details', 'mailgun'); ?>
+				</th>
+				<td>
+					<select name="mailgun[override-from]">
+						<option value="1"<?php selected('1', $this->get_option('override-from', null, '0')); ?>><?php _e('Yes', 'mailgun'); ?></option>
+						<option value="0"<?php selected('0', $this->get_option('override-from', null, '0')); ?>><?php _e('No', 'mailgun'); ?></option>
+					</select>
+					<p class="description">
+						<?php
+							_e('If enabled, all emails will be sent with the above "From Name" and "From Address", regardless of values set by other plugins. Useful for cases where other plugins don\'t play nice with our "From Name" / "From Address" setting.', 'mailgun');
+						?>
+					</p>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row">
+					<?php _e('Tag', 'mailgun'); ?>
+				</th>
+				<td>
+					<input type="text" class="regular-text"
+						   name="mailgun[campaign-id]"
+						   value="<?php esc_attr_e($this->get_option('campaign-id')); ?>"
+						   placeholder="tag"
+					/>
+					<p class="description">
+						<?php
+							_e('If added, this tag will exist on every outbound message. Statistics will be populated in the Mailgun Control Panel. Use a comma to define multiple tags. ', 'mailgun');
+							_e('Learn more about', 'mailgun');
+
+							$url1 = 'https://documentation.mailgun.com/user_manual.html#tracking-messages';
+							$url2 = 'https://documentation.mailgun.com/user_manual.html#tagging';
+							$link = sprintf(
+								wp_kses(
+									__('<a href="%1$s" target="%3$s">Tracking</a> and <a href="%2$s">Tagging</a>', 'mailgun'),
+									array('a' => array(
+										'href' => array(),
+										'target' => array()
+										)
+									)
+								), esc_url($url1), esc_url($url2), '_blank'
+							);
+							echo $link;
+						?>
+					</p>
+				</td>
+			</tr>
+		</table>
+		<?php else: ?>
+			<p>
 				<?php
-					_e('A <a target="_blank" href="http://www.mailgun.com/">Mailgun</a> account is required to use this plugin and the Mailgun service.', 'mailgun');
+					_e('Once you have configured the plugin settings in your wp-config.php, you can test it here.', 'mailgun');
 				?>
 			</p>
-            <p>
-				<?php
-					_e('If you need to register for an account, you can do so at <a target="_blank" href="http://www.mailgun.com/">http://www.mailgun.com/</a>.', 'mailgun');
-				?>
-			</p>
-
-			<h3><?php _e('Configuration', 'mailgun'); ?></h3>
-
-			<?php
-				$isMultisite = defined('WP_ALLOW_MULTISITE');
-				if (!$isMultisite):
-			?>
-            <form id="mailgun-form" action="options.php" method="post">
-                <?php settings_fields('mailgun'); ?>
-
-                <table class="form-table">
-					<tr valign="top">
-						<th scope="row">
-			                <?php _e('Select Your Region', 'mailgun'); ?>
-						</th>
-						<td>
-							<select id="mailgun-region" name="mailgun[region]">
-								<option value="us"<?php selected('us', $this->get_option('region')); ?>><?php _e('U.S./North America', 'mailgun') ?></option>
-								<option value="eu"<?php selected('eu', $this->get_option('region')); ?>><?php _e('Europe', 'mailgun') ?></option>
-							</select>
-							<p class="description">
-								<?php
-									_e('Choose a region - U.S./North America or Europe - from which to send email, and to store your customer data. Please note that your sending domain must be set up in whichever region you choose.', 'mailgun');
-								?>
-							</p>
-						</td>
-					</tr>
-                    <tr valign="top">
-                        <th scope="row">
-                            <?php _e('Use HTTP API', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <select id="mailgun-api" name="mailgun[useAPI]">
-                                <option value="1"<?php selected('1', $this->get_option('useAPI')); ?>><?php _e('Yes', 'mailgun'); ?></option>
-                                <option value="0"<?php selected('0', $this->get_option('useAPI')); ?>><?php _e('No', 'mailgun'); ?></option>
-                            </select>
-                            <p class="description"><?php _e('Set this to "No" if your server cannot make outbound HTTP connections or if emails are not being delivered. "No" will cause this plugin to use SMTP. Default "Yes".', 'mailgun'); ?></p>
-                        </td>
-                    </tr>
-                    <tr valign="top">
-                        <th scope="row">
-                            <?php _e('Mailgun Domain Name', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <input type="text" class="regular-text" name="mailgun[domain]" value="<?php esc_attr_e($this->get_option('domain')); ?>" placeholder="samples.mailgun.org" />
-                            <p class="description"><?php _e('Your Mailgun Domain Name.', 'mailgun'); ?></p>
-                        </td>
-                    </tr>
-                    <tr valign="top" class="mailgun-api">
-                        <th scope="row">
-                            <?php _e('API Key', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <input type="text" class="regular-text" name="mailgun[apiKey]" value="<?php esc_attr_e($this->get_option('apiKey')); ?>" placeholder="key-3ax6xnjp29jd6fds4gc373sgvjxteol0" />
-                            <p class="description"><?php _e('Your Mailgun API key. Only valid for use with the API.', 'mailgun'); ?></p>
-                        </td>
-                    </tr>
-                    <tr valign="top" class="mailgun-smtp">
-                        <th scope="row">
-                            <?php _e('Username', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <input type="text" class="regular-text" name="mailgun[username]" value="<?php esc_attr_e($this->get_option('username')); ?>" placeholder="postmaster" />
-                            <p class="description"><?php _e('Your Mailgun SMTP username. Only valid for use with SMTP.', 'mailgun'); ?></p>
-                        </td>
-                    </tr>
-                    <tr valign="top" class="mailgun-smtp">
-                        <th scope="row">
-                            <?php _e('Password', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <input type="text" class="regular-text" name="mailgun[password]" value="<?php esc_attr_e($this->get_option('password')); ?>" placeholder="my-password" />
-                            <p class="description"><?php _e('Your Mailgun SMTP password that goes with the above username. Only valid for use with SMTP.', 'mailgun'); ?></p>
-                        </td>
-                    </tr>
-                    <tr valign="top" class="mailgun-smtp">
-                        <th scope="row">
-                            <?php _e('Use Secure SMTP', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <select name="mailgun[secure]">
-                                <option value="1"<?php selected('1', $this->get_option('secure')); ?>><?php _e('Yes', 'mailgun'); ?></option>
-                                <option value="0"<?php selected('0', $this->get_option('secure')); ?>><?php _e('No', 'mailgun'); ?></option>
-                            </select>
-                            <p class="description"><?php _e('Set this to "No" if your server cannot establish SSL SMTP connections or if emails are not being delivered. If you set this to "No" your password will be sent in plain text. Only valid for use with SMTP. Default "Yes".', 'mailgun'); ?></p>
-                        </td>
-                    </tr>
-                    <tr valign="top" class="mailgun-smtp">
-                        <th scope="row">
-                            <?php _e('Security Type', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <select name="mailgun[sectype]">
-                                <option value="ssl"<?php selected('ssl', $this->get_option('sectype')); ?>>SSL</option>
-                                <option value="tls"<?php selected('tls', $this->get_option('sectype')); ?>>TLS</option>
-                            </select>
-                            <p class="description"><php _e('Leave this at "TLS" unless mail sending fails. This option only matters for Secure SMTP. Default "TLS".', 'mailgun'); ?></p>
-                        </td>
-                    </tr>
-                    <tr valign="top">
-                        <th scope="row">
-                            <?php _e('Click Tracking', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <select name="mailgun[track-clicks]">
-                                <option value="htmlonly"<?php selected('htmlonly', $this->get_option('track-clicks')); ?>><?php _e('HTML Only', 'mailgun'); ?></option>
-                                <option value="yes"<?php selected('yes', $this->get_option('track-clicks')); ?>><?php _e('Yes', 'mailgun'); ?></option>
-                                <option value="no"<?php selected('no', $this->get_option('track-clicks')); ?>><?php _e('No', 'mailgun'); ?></option>
-                            </select>
-                            <p class="description"><?php _e('If enabled, Mailgun will  and track links.', 'mailgun'); ?> <a href="http://documentation.mailgun.com/user_manual.html#tracking-clicks" target="_blank">Click Tracking Documentation</a></p>
-                        </td>
-                    </tr>
-                    <tr valign="top">
-                        <th scope="row">
-                            <?php _e('Open Tracking', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <select name="mailgun[track-opens]">
-                                <option value="1"<?php selected('1', $this->get_option('track-opens')); ?>><?php _e('Yes', 'mailgun'); ?></option>
-                                <option value="0"<?php selected('0', $this->get_option('track-opens')); ?>><?php _e('No', 'mailgun'); ?></option>
-                            </select>
-                            <p class="description"><?php _e('If enabled, HTML messages will include an open tracking beacon.', 'mailgun'); ?> <a href="http://documentation.mailgun.com/user_manual.html#tracking-opens" target="_blank">Open Tracking Documentation</a></p>
-                        </td>
-                    </tr>
-                    <tr valign="top">
-                        <th scope="row">
-                            <?php _e('From Address', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <input type="text" class="regular-text" name="mailgun[from-address]" value="<?php esc_attr_e($this->get_option('from-address')); ?>" placeholder="wordpress@mydomain.com" />
-                            <p class="description"><?php _e('The <address@mydomain.com> part of the sender information (<code>"Excited User &lt;user@samples.mailgun.org&gt;"</code>). This address will appear as the `From` address on sent mail. <strong>It is recommended that the @mydomain portion matches your Mailgun sending domain.</strong>', 'mailgun'); ?></p>
-                        </td>
-                    </tr>
-                    <tr valign="top">
-                        <th scope="row">
-                            <?php _e('From Name', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <input type="text" class="regular-text" name="mailgun[from-name]" value="<?php esc_attr_e($this->get_option('from-name')); ?>" placeholder="WordPress" />
-                            <p class="description"><?php _e('The "User Name" part of the sender information (<code>"Excited User &lt;user@samples.mailgun.org&gt;"</code>).', 'mailgun'); ?></p>
-                        </td>
-                    </tr>
-                    <tr valign="top">
-                        <th scope="row">
-                            <?php _e('Override "From" Details', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <select name="mailgun[override-from]">
-                                <option value="1"<?php selected('1', $this->get_option('override-from', null, '0')); ?>><?php _e('Yes', 'mailgun'); ?></option>
-                                <option value="0"<?php selected('0', $this->get_option('override-from', null, '0')); ?>><?php _e('No', 'mailgun'); ?></option>
-                            </select>
-                            <p class="description"><?php _e('If enabled, all emails will be sent with the above "From Name" and "From Address", regardless of values set by other plugins. Useful for cases where other plugins don\'t play nice with our "From Name" / "From Address" setting.', 'mailgun'); ?></p>
-                        </td>
-                    </tr>
-                    <tr valign="top">
-                        <th scope="row">
-                            <?php _e('Tag', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <input type="text" class="regular-text" name="mailgun[campaign-id]" value="<?php esc_attr_e($this->get_option('campaign-id')); ?>" placeholder="tag" />
-                            <p class="description"><?php _e('If added, this tag will exist on every outbound message. Statistics will be populated in the Mailgun Control Panel. Use a comma to define multiple tags.', 'mailgun'); ?> <?php _e('Learn more about', 'mailgun'); ?> <a href="https://documentation.mailgun.com/user_manual.html#tracking-messages" target="_blank">Tracking</a> <?php _e('and', 'mailgun'); ?> <a href="https://documentation.mailgun.com/user_manual.html#tagging" target="_blank">Tagging</a>.</p>
-                        </td>
-                    </tr>
-                </table>
-			<?php else: ?>
-				<p>
-					<?php
-						_e('Once you have configured the plugin settings in your wp-config.php, you can test it here.', 'mailgun');
-					?>
-				</p>
-				<p><?php _e('The definitions are as follows:', 'mailgun'); ?></p>
-				<p><pre>
-MAILGUN_REGION       Choices: 'us' or 'eu'
-    ex. define('MAILGUN_REGION', 'us');
-MAILGUN_USEAPI       Choices: '0' or '1' (0 = false/no)
+			<p><?php _e('The definitions are as follows:', 'mailgun'); ?></p>
+			<p>
+			<pre>
+MAILGUN_REGION		Choices: 'us' or 'eu'
+	ex. define('MAILGUN_REGION', 'us');
+MAILGUN_USEAPI		Choices: '0' or '1' (0 = false/no)
 MAILGUN_APIKEY
 MAILGUN_DOMAIN
 MAILGUN_USERNAME
 MAILGUN_PASSWORD
 MAILGUN_SECURE
-MAILGUN_SECTYPE       Choices: 'ssl' or 'tls'
+MAILGUN_SECTYPE		Choices: 'ssl' or 'tls'
 MAILGUN_FROM_NAME
 MAILGUN_FROM_ADDRESS
-				</pre></p>
-			<?php endif; ?>
-                <h3><?php _e('Lists', 'mailgun'); ?></h3>
-                <table class="form-table">
-                    <tr valign="top">
-                        <th scope="row">
-                            <?php _e('Shortcode', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <div>
-								<code>[mailgun id="<em>{mailgun list id}</em>" collect_name="true"]</code>
-                            </div>
-                            <div>
-                                <p class="description">
-									<?php
-										_e('Use the shortcode above to associate a widget instance with a mailgun list', 'mailgun');
-									?>
-								</p>
-                            </div>
-                        </td>
-                    </tr>
-                    <tr valign="top">
-                        <th scope="row">
-                            <?php _e('Lists', 'mailgun'); ?>
-                        </th>
-                        <td>
-                            <?php
-                            	_e('<a href="?page=mailgun-lists">View available lists</a>', 'mailgun');
-                            ?>
-                        </td>
-                    </tr>
-                </table>
-
-				<?php if(!$isMultisite): ?>
-                <p>
+			</pre>
+			</p>
+		<?php endif; ?>
+		<h3><?php _e('Lists', 'mailgun'); ?></h3>
+		<table class="form-table">
+			<tr valign="top">
+				<th scope="row">
+					<?php _e('Shortcode', 'mailgun'); ?>
+				</th>
+				<td>
+					<div>
+						<code>[mailgun id="<em>{mailgun list id}</em>" collect_name="true"]</code>
+					</div>
+					<div>
+						<p class="description">
+							<?php
+								_e('Use the shortcode above to associate a widget instance with a mailgun list', 'mailgun');
+							?>
+						</p>
+					</div>
+				</td>
+			</tr>
+			<tr valign="top">
+				<th scope="row">
+					<?php _e('Lists', 'mailgun'); ?>
+				</th>
+				<td>
 					<?php
-						_e('Before attempting to test the configuration, please click "Save Changes".', 'mailgun');
+						$url = '?page=mailgun-lists';
+
+						$link = sprintf(
+							wp_kses(
+								__('<a href="%1$s" target="%2$s">View available lists</a>.', 'mailgun'),
+								array('a' => array(
+									'href' => array(),
+									'target' => array()
+									)
+								)
+							), esc_url($url), '_blank'
+						);
+						echo $link;
 					?>
-				</p>
-                <p class="submit">
-                    <input type="submit" class="button-primary" value="<?php _e('Save Changes', 'mailgun'); ?>" />
-                    <input type="button" id="mailgun-test" class="button-secondary" value="<?php _e('Test Configuration', 'mailgun'); ?>" />
-                </p>
-				<?php else: ?>
-					<p class="submit">
-						<input type="button" id="mailgun-test" class="button-secondary" value="<?php _e('Test Configuration', 'mailgun'); ?>" />
-					</p>
-				<?php endif; ?>
-            </form>
-        </div>
+				</td>
+			</tr>
+		</table>
+
+		<?php if (!$isMultisite): ?>
+			<p>
+				<?php
+					_e('Before attempting to test the configuration, please click "Save Changes".', 'mailgun');
+				?>
+			</p>
+			<p class="submit">
+				<input type="submit"
+					   class="button-primary"
+					   value="<?php _e('Save Changes', 'mailgun'); ?>"
+				/>
+				<input type="button"
+					   id="mailgun-test"
+					   class="button-secondary"
+					   value="<?php _e('Test Configuration', 'mailgun'); ?>"
+				/>
+			</p>
+		<?php else: ?>
+			<p class="submit">
+				<input type="button"
+					   id="mailgun-test"
+					   class="button-secondary"
+					   value="<?php _e('Test Configuration', 'mailgun'); ?>"
+				/>
+			</p>
+		<?php endif; ?>
+	</form>
+</div>

--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -22,39 +22,47 @@
 ?>
         <div class="wrap">
             <div id="icon-options-general" class="icon32"><br /></div>
-            <span class="alignright"><a target="_blank" href="http://www.mailgun.com/"><img src="https://assets.mailgun.com/img/mailgun.svg" alt="Mailgun" style="width: 10em;"/></a></span>
+            <span class="alignright">
+				<a target="_blank" href="http://www.mailgun.com/">
+					<img src="https://assets.mailgun.com/img/mailgun.svg" alt="Mailgun" style="width:10em;"/>
+				</a>
+			</span>
             <h2><?php _e('Mailgun', 'mailgun'); ?></h2>
-            <p>A <a target="_blank" href="http://www.mailgun.com/">Mailgun</a> account is required to use this plugin and the Mailgun service.</p>
-            <p>If you need to register for an account, you can do so at <a target="_blank" href="http://www.mailgun.com/">http://www.mailgun.com/</a>.</p>
+            <p>
+				<?php
+					_e('A <a target="_blank" href="http://www.mailgun.com/">Mailgun</a> account is required to use this plugin and the Mailgun service.', 'mailgun');
+				?>
+			</p>
+            <p>
+				<?php
+					_e('If you need to register for an account, you can do so at <a target="_blank" href="http://www.mailgun.com/">http://www.mailgun.com/</a>.', 'mailgun');
+				?>
+			</p>
+
+			<h3><?php _e('Configuration', 'mailgun'); ?></h3>
+
+			<?php
+				$isMultisite = defined('WP_ALLOW_MULTISITE');
+				if (!$isMultisite):
+			?>
             <form id="mailgun-form" action="options.php" method="post">
                 <?php settings_fields('mailgun'); ?>
-                <h3><?php _e('Configuration', 'mailgun'); ?></h3>
+
                 <table class="form-table">
 					<tr valign="top">
 						<th scope="row">
-			                <?php
-				                $config_region = (defined('MAILGUN_REGION') && MAILGUN_REGION);
-				                if ($config_region):
-					                _e('Your Region is', 'mailgun');
-				                else:
-					                _e('Select Your Region', 'mailgun');
-				                endif;
-			                ?>
+			                <?php _e('Select Your Region', 'mailgun'); ?>
 						</th>
 						<td>
-			                <?php
-				                if ($config_region):
-					                $region = (MAILGUN_REGION === 'us') ? __('U.S./North America', 'mailgun') : __('Europe', 'mailgun');
-					                ?>
-									<input readonly="readonly" id="mailgun-region" type="text" name="mailgun[region]" value="<?php echo $region ?>">
-									<p class="description"><?php _e('You have set the region in your wp-config.php file. Email will be sent from this region, and your customer data will be stored in this region.', 'mailgun') ?></p>
-				                <?php else: ?>
-									<select id="mailgun-region" name="mailgun[region]">
-										<option value="us"<?php selected('us', $this->get_option('region')); ?>><?php _e('U.S./North America', 'mailgun') ?></option>
-										<option value="eu"<?php selected('eu', $this->get_option('region')); ?>><?php _e('Europe', 'mailgun') ?></option>
-									</select>
-									<p class="description"><?php _e('Choose a region - U.S./North America or Europe - from which to send email, and to store your customer data. Please note that your sending domain must be set up in whichever region you choose.', 'mailgun') ?></p>
-				                <?php endif; ?>
+							<select id="mailgun-region" name="mailgun[region]">
+								<option value="us"<?php selected('us', $this->get_option('region')); ?>><?php _e('U.S./North America', 'mailgun') ?></option>
+								<option value="eu"<?php selected('eu', $this->get_option('region')); ?>><?php _e('Europe', 'mailgun') ?></option>
+							</select>
+							<p class="description">
+								<?php
+									_e('Choose a region - U.S./North America or Europe - from which to send email, and to store your customer data. Please note that your sending domain must be set up in whichever region you choose.', 'mailgun');
+								?>
+							</p>
 						</td>
 					</tr>
                     <tr valign="top">
@@ -194,6 +202,27 @@
                         </td>
                     </tr>
                 </table>
+			<?php else: ?>
+				<p>
+					<?php
+						_e('Once you have configured the plugin settings in your wp-config.php, you can test it here.', 'mailgun');
+					?>
+				</p>
+				<p><?php _e('The definitions are as follows:', 'mailgun'); ?></p>
+				<p><pre>
+MAILGUN_REGION       Choices: 'us' or 'eu'
+    ex. define('MAILGUN_REGION', 'us');
+MAILGUN_USEAPI       Choices: '0' or '1' (0 = false/no)
+MAILGUN_APIKEY
+MAILGUN_DOMAIN
+MAILGUN_USERNAME
+MAILGUN_PASSWORD
+MAILGUN_SECURE
+MAILGUN_SECTYPE       Choices: 'ssl' or 'tls'
+MAILGUN_FROM_NAME
+MAILGUN_FROM_ADDRESS
+				</pre></p>
+			<?php endif; ?>
                 <h3><?php _e('Lists', 'mailgun'); ?></h3>
                 <table class="form-table">
                     <tr valign="top">
@@ -202,10 +231,14 @@
                         </th>
                         <td>
                             <div>
-                                <strong>[mailgun id="<em>{mailgun list id}</em>" collect_name="true"]</strong>
+								<code>[mailgun id="<em>{mailgun list id}</em>" collect_name="true"]</code>
                             </div>
                             <div>
-                                <p class="description"><?php _e('Use the shortcode above to associate a widget instance with a mailgun list', 'mailgun'); ?></p>
+                                <p class="description">
+									<?php
+										_e('Use the shortcode above to associate a widget instance with a mailgun list', 'mailgun');
+									?>
+								</p>
                             </div>
                         </td>
                     </tr>
@@ -214,15 +247,27 @@
                             <?php _e('Lists', 'mailgun'); ?>
                         </th>
                         <td>
-                            <a href="?page=mailgun-lists">View available lists</a>
+                            <?php
+                            	_e('<a href="?page=mailgun-lists">View available lists</a>', 'mailgun');
+                            ?>
                         </td>
                     </tr>
                 </table>
 
-                <p><?php _e('Before attempting to test the configuration, please click "Save Changes".', 'mailgun'); ?></p>
+				<?php if(!$isMultisite): ?>
+                <p>
+					<?php
+						_e('Before attempting to test the configuration, please click "Save Changes".', 'mailgun');
+					?>
+				</p>
                 <p class="submit">
                     <input type="submit" class="button-primary" value="<?php _e('Save Changes', 'mailgun'); ?>" />
                     <input type="button" id="mailgun-test" class="button-secondary" value="<?php _e('Test Configuration', 'mailgun'); ?>" />
                 </p>
+				<?php else: ?>
+					<p class="submit">
+						<input type="button" id="mailgun-test" class="button-secondary" value="<?php _e('Test Configuration', 'mailgun'); ?>" />
+					</p>
+				<?php endif; ?>
             </form>
         </div>

--- a/languages/mailgun-template.po
+++ b/languages/mailgun-template.po
@@ -61,10 +61,6 @@ msgstr ""
 msgid "Mailgun is almost ready. "
 msgstr ""
 
-#: includes/admin.php:301
-msgid "You must <a href=\"%1$s\">configure Mailgun</a> for it to work."
-msgstr ""
-
 #: includes/admin.php:309
 msgid ""
 "\"Override From\" option requires that \"From Name\" and \"From Address\" be "

--- a/mailgun.php
+++ b/mailgun.php
@@ -1,479 +1,486 @@
 <?php
 
-/**
- * Plugin Name:  Mailgun
- * Plugin URI:   http://wordpress.org/extend/plugins/mailgun/
- * Description:  Mailgun integration for WordPress
- * Version:      1.6
- * Author:       Mailgun
- * Author URI:   http://www.mailgun.com/
- * License:      GPLv2 or later
- * Text Domain:  mailgun
- * Domain Path:  /languages/.
- */
+	/**
+	 * Plugin Name:  Mailgun
+	 * Plugin URI:   http://wordpress.org/extend/plugins/mailgun/
+	 * Description:  Mailgun integration for WordPress
+	 * Version:      1.6
+	 * Author:       Mailgun
+	 * Author URI:   http://www.mailgun.com/
+	 * License:      GPLv2 or later
+	 * Text Domain:  mailgun
+	 * Domain Path:  /languages/.
+	 */
 
-/*
- * mailgun-wordpress-plugin - Sending mail from Wordpress using Mailgun
- * Copyright (C) 2016 Mailgun, et al.
- *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; either version 2 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License along
- * with this program; if not, write to the Free Software Foundation, Inc.,
- * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
- */
+	/*
+	 * mailgun-wordpress-plugin - Sending mail from Wordpress using Mailgun
+	 * Copyright (C) 2016 Mailgun, et al.
+	 *
+	 * This program is free software; you can redistribute it and/or modify
+	 * it under the terms of the GNU General Public License as published by
+	 * the Free Software Foundation; either version 2 of the License, or
+	 * (at your option) any later version.
+	 *
+	 * This program is distributed in the hope that it will be useful,
+	 * but WITHOUT ANY WARRANTY; without even the implied warranty of
+	 * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+	 * GNU General Public License for more details.
+	 *
+	 * You should have received a copy of the GNU General Public License along
+	 * with this program; if not, write to the Free Software Foundation, Inc.,
+	 * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+	 */
 
-/**
- * Entrypoint for the Mailgun plugin. Sets up the mailing "strategy" -
- * either API or SMTP.
- *
- * Registers handlers for later actions and sets up config variables with
- * Wordpress.
- */
-class Mailgun
-{
-    /**
-     * Setup shared functionality for Admin and Front End.
-     *
-     * @since	0.1
-     */
-    public function __construct()
-    {
-        $this->options = get_option('mailgun');
-        $this->plugin_file = __FILE__;
-        $this->plugin_basename = plugin_basename($this->plugin_file);
+	/**
+	 * Entrypoint for the Mailgun plugin. Sets up the mailing "strategy" -
+	 * either API or SMTP.
+	 *
+	 * Registers handlers for later actions and sets up config variables with
+	 * Wordpress.
+	 */
+	class Mailgun
+	{
+		/**
+		 * Setup shared functionality for Admin and Front End.
+		 *
+		 * @since    0.1
+		 */
+		public function __construct()
+		{
+			$this->options = get_option('mailgun');
+			$this->plugin_file = __FILE__;
+			$this->plugin_basename = plugin_basename($this->plugin_file);
 
-        // Either override the wp_mail function or configure PHPMailer to use the
-        // Mailgun SMTP servers
-        // When using SMTP, we also need to inject a `wp_mail` filter to make "from" settings
-        // work properly. Fixes issues with 1.5.7+
-        if ($this->get_option('useAPI') || (defined('MAILGUN_USEAPI') && MAILGUN_USEAPI)):
-            if (!function_exists('wp_mail')):
-                if (!include dirname(__FILE__).'/includes/wp-mail-api.php'):
-                    self::deactivate_and_die(dirname(__FILE__).'/includes/wp-mail-api.php');
-                endif;
-            endif;
-        else:
-            // Using SMTP, include the SMTP filter
-            if (!function_exists('mg_smtp_mail_filter')):
-                if (!include dirname(__FILE__).'/includes/wp-mail-smtp.php'):
-                    self::deactivate_and_die(dirname(__FILE__).'/includes/wp-mail-smtp.php');
-                endif;
-            endif;
-            add_filter('wp_mail', 'mg_smtp_mail_filter');
-            add_action('phpmailer_init', array(&$this, 'phpmailer_init'));
-            add_action('wp_mail_failed', 'wp_mail_failed');
-        endif;
-    }
+			// Either override the wp_mail function or configure PHPMailer to use the
+			// Mailgun SMTP servers
+			// When using SMTP, we also need to inject a `wp_mail` filter to make "from" settings
+			// work properly. Fixes issues with 1.5.7+
+			if ($this->get_option('useAPI') || (defined('MAILGUN_USEAPI') && MAILGUN_USEAPI)):
+				if (!function_exists('wp_mail')):
+					if (!include dirname(__FILE__) . '/includes/wp-mail-api.php'):
+						self::deactivate_and_die(dirname(__FILE__) . '/includes/wp-mail-api.php');
+					endif;
+				endif;
+			else:
+				// Using SMTP, include the SMTP filter
+				if (!function_exists('mg_smtp_mail_filter')):
+					if (!include dirname(__FILE__) . '/includes/wp-mail-smtp.php'):
+						self::deactivate_and_die(dirname(__FILE__) . '/includes/wp-mail-smtp.php');
+					endif;
+				endif;
+				add_filter('wp_mail', 'mg_smtp_mail_filter');
+				add_action('phpmailer_init', array(&$this, 'phpmailer_init'));
+				add_action('wp_mail_failed', 'wp_mail_failed');
+			endif;
+		}
 
-    /**
-     * Get specific option from the options table.
-     *
-     * @param	string	$option		Name of option to be used as array key for retrieving the specific value
-     * @param	array	$options	Array to iterate over for specific values
-     * @param	bool	$default	False if no options are set
-     *
-     * @return	mixed
-     *
-     * @since	0.1
-     */
-    public function get_option($option, $options = null, $default = false)
-    {
-        if (is_null($options)):
-            $options = &$this->options;
-        endif;
-        if (isset($options[$option])):
-            return $options[$option];
-        else:
-            return $default;
-        endif;
-    }
+		/**
+		 * Get specific option from the options table.
+		 *
+		 * @param    string $option  Name of option to be used as array key for retrieving the specific value
+		 * @param    array  $options Array to iterate over for specific values
+		 * @param    bool   $default False if no options are set
+		 *
+		 * @return    mixed
+		 *
+		 * @since    0.1
+		 */
+		public function get_option($option, $options = null, $default = false)
+		{
+			if (is_null($options)):
+				$options = &$this->options;
+			endif;
+			if (isset($options[ $option ])):
+				return $options[ $option ];
+			else:
+				return $default;
+			endif;
+		}
 
-    /**
-     * Hook into phpmailer to override SMTP based configurations
-     * to use the Mailgun SMTP server.
-     *
-     * @param	object	$phpmailer	The PHPMailer object to modify by reference
-     *
-     * @return	void
-     *
-     * @since	0.1
-     */
-    public function phpmailer_init(&$phpmailer)
-    {
-        $username = (defined('MAILGUN_USERNAME') && MAILGUN_USERNAME) ? MAILGUN_USERNAME : $this->get_option('username');
-        $domain = (defined('MAILGUN_DOMAIN') && MAILGUN_DOMAIN) ? MAILGUN_DOMAIN : $this->get_option('domain');
-        $username = preg_replace('/@.+$/', '', $username)."@{$domain}";
-        $secure = (defined('MAILGUN_SECURE') && MAILGUN_SECURE) ? MAILGUN_SECURE : $this->get_option('secure');
-        $sectype = (defined('MAILGUN_SECTYPE') && MAILGUN_SECTYPE) ? MAILGUN_SECTYPE : $this->get_option('sectype');
-        $password = (defined('MAILGUN_PASSWORD') && MAILGUN_PASSWORD) ? MAILGUN_PASSWORD : $this->get_option('password');
-        $region = (defined('MAILGUN_REGION') && MAILGUN_REGION) ? MAILGUN_REGION : $this->get_option('region');
+		/**
+		 * Hook into phpmailer to override SMTP based configurations
+		 * to use the Mailgun SMTP server.
+		 *
+		 * @param    object $phpmailer The PHPMailer object to modify by reference
+		 *
+		 * @return    void
+		 *
+		 * @since    0.1
+		 */
+		public function phpmailer_init(&$phpmailer)
+		{
+			$username = (defined('MAILGUN_USERNAME') && MAILGUN_USERNAME) ? MAILGUN_USERNAME : $this->get_option('username');
+			$domain = (defined('MAILGUN_DOMAIN') && MAILGUN_DOMAIN) ? MAILGUN_DOMAIN : $this->get_option('domain');
+			$username = preg_replace('/@.+$/', '', $username) . "@{$domain}";
+			$secure = (defined('MAILGUN_SECURE') && MAILGUN_SECURE) ? MAILGUN_SECURE : $this->get_option('secure');
+			$sectype = (defined('MAILGUN_SECTYPE') && MAILGUN_SECTYPE) ? MAILGUN_SECTYPE : $this->get_option('sectype');
+			$password = (defined('MAILGUN_PASSWORD') && MAILGUN_PASSWORD) ? MAILGUN_PASSWORD : $this->get_option('password');
+			$region = (defined('MAILGUN_REGION') && MAILGUN_REGION) ? MAILGUN_REGION : $this->get_option('region');
 
-        $smtp_endpoint = mg_smtp_get_region($region);
-        $smtp_endpoint = (bool) $smtp_endpoint ? $smtp_endpoint : 'smtp.mailgun.org';
+			$smtp_endpoint = mg_smtp_get_region($region);
+			$smtp_endpoint = (bool) $smtp_endpoint ? $smtp_endpoint : 'smtp.mailgun.org';
 
-        $phpmailer->Mailer = 'smtp';
-        $phpmailer->Host = $smtp_endpoint;
+			$phpmailer->Mailer = 'smtp';
+			$phpmailer->Host = $smtp_endpoint;
 
-        if ( 'ssl' === $sectype ):
-            // For SSL-only connections, use 465
-            $phpmailer->Port = 465;
-        else:
-            // Otherwise, use 587.
-            $phpmailer->Port = 587;
-        endif;
+			if ('ssl' === $sectype):
+				// For SSL-only connections, use 465
+				$phpmailer->Port = 465;
+			else:
+				// Otherwise, use 587.
+				$phpmailer->Port = 587;
+			endif;
 
-        $phpmailer->SMTPAuth = true;
-        $phpmailer->Username = $username;
-        $phpmailer->Password = $password;
+			$phpmailer->SMTPAuth = true;
+			$phpmailer->Username = $username;
+			$phpmailer->Password = $password;
 
-        $phpmailer->SMTPSecure = (bool) $secure ? $sectype : '';
-        // Without this line... wp_mail for SMTP-only will always return false. But why? :(
-        $phpmailer->Debugoutput = 'mg_smtp_debug_output';
-        $phpmailer->SMTPDebug = 2;
+			$phpmailer->SMTPSecure = (bool) $secure ? $sectype : '';
+			// Without this line... wp_mail for SMTP-only will always return false. But why? :(
+			$phpmailer->Debugoutput = 'mg_smtp_debug_output';
+			$phpmailer->SMTPDebug = 2;
 
-        // Emit some logging for SMTP connection
-        mg_smtp_debug_output(sprintf("PHPMailer configured to send via %s:%s", $phpmailer->Host, $phpmailer->Port), 'DEBUG');
-    }
+			// Emit some logging for SMTP connection
+			mg_smtp_debug_output(sprintf("PHPMailer configured to send via %s:%s", $phpmailer->Host, $phpmailer->Port),
+				'DEBUG');
+		}
 
-    /**
-     * Deactivate this plugin and die.
-     * Deactivate the plugin when files critical to it's operation cannot be loaded
-     *
-     * @param	$file	Files critical to plugin functionality
-     *
-     * @return	void
-     *
-     * @since	0.1
-     */
-    public function deactivate_and_die($file)
-    {
-        load_plugin_textdomain('mailgun', false, 'mailgun/languages');
-        $message = sprintf(__('Mailgun has been automatically deactivated because the file <strong>%s</strong> is missing. Please reinstall the plugin and reactivate.'), $file);
-        if (!function_exists('deactivate_plugins')):
-            include ABSPATH.'wp-admin/includes/plugin.php';
-        endif;
-        deactivate_plugins(__FILE__);
-        wp_die($message);
-    }
+		/**
+		 * Deactivate this plugin and die.
+		 * Deactivate the plugin when files critical to it's operation cannot be loaded
+		 *
+		 * @param    $file    Files critical to plugin functionality
+		 *
+		 * @return    void
+		 *
+		 * @since    0.1
+		 */
+		public function deactivate_and_die($file)
+		{
+			load_plugin_textdomain('mailgun', false, 'mailgun/languages');
+			$message = sprintf(__('Mailgun has been automatically deactivated because the file <strong>%s</strong> is missing. Please reinstall the plugin and reactivate.'),
+				$file);
+			if (!function_exists('deactivate_plugins')):
+				include ABSPATH . 'wp-admin/includes/plugin.php';
+			endif;
+			deactivate_plugins(__FILE__);
+			wp_die($message);
+		}
 
-    /**
-     * Make a Mailgun api call.
-     *
-     * @param	string	$uri	The endpoint for the Mailgun API
-     * @param	array	$params	Array of parameters passed to the API
-     * @param	string	$method	The form request type
-     *
-     * @return	array
-     *
-     * @since	0.1
-     */
-    public function api_call($uri, $params = array(), $method = 'POST')
-    {
-        $options = get_option('mailgun');
-        $getRegion = (defined('MAILGUN_REGION') && MAILGUN_REGION) ? MAILGUN_REGION : $options['region'];
-        $apiKey = (defined('MAILGUN_APIKEY') && MAILGUN_APIKEY) ? MAILGUN_APIKEY : $options['apiKey'];
-        $domain = (defined('MAILGUN_DOMAIN') && MAILGUN_DOMAIN) ? MAILGUN_DOMAIN : $options['domain'];
+		/**
+		 * Make a Mailgun api call.
+		 *
+		 * @param    string $uri    The endpoint for the Mailgun API
+		 * @param    array  $params Array of parameters passed to the API
+		 * @param    string $method The form request type
+		 *
+		 * @return    array
+		 *
+		 * @since    0.1
+		 */
+		public function api_call($uri, $params = array(), $method = 'POST')
+		{
+			$options = get_option('mailgun');
+			$getRegion = (defined('MAILGUN_REGION') && MAILGUN_REGION) ? MAILGUN_REGION : $options[ 'region' ];
+			$apiKey = (defined('MAILGUN_APIKEY') && MAILGUN_APIKEY) ? MAILGUN_APIKEY : $options[ 'apiKey' ];
+			$domain = (defined('MAILGUN_DOMAIN') && MAILGUN_DOMAIN) ? MAILGUN_DOMAIN : $options[ 'domain' ];
 
-        $region = mg_api_get_region($getRegion);
-        $this->api_endpoint = ($region) ? $region : 'https://api.mailgun.net/v3/';
+			$region = mg_api_get_region($getRegion);
+			$this->api_endpoint = ($region) ? $region : 'https://api.mailgun.net/v3/';
 
-        $time = time();
-        $url = $this->api_endpoint.$uri;
-        $headers = array(
-            'Authorization' => 'Basic '.base64_encode("api:{$apiKey}"),
-        );
+			$time = time();
+			$url = $this->api_endpoint . $uri;
+			$headers = array(
+				'Authorization' => 'Basic ' . base64_encode("api:{$apiKey}"),
+			);
 
-        switch ($method) {
-        case 'GET':
-            $params['sess'] = '';
-            $querystring = http_build_query($params);
-            $url = $url.'?'.$querystring;
-            $params = '';
-            break;
-        case 'POST':
-        case 'PUT':
-        case 'DELETE':
-            $params['sess'] = '';
-            $params['time'] = $time;
-            $params['hash'] = sha1(date('U'));
-            break;
-        }
+			switch ($method) {
+				case 'GET':
+					$params[ 'sess' ] = '';
+					$querystring = http_build_query($params);
+					$url = $url . '?' . $querystring;
+					$params = '';
+					break;
+				case 'POST':
+				case 'PUT':
+				case 'DELETE':
+					$params[ 'sess' ] = '';
+					$params[ 'time' ] = $time;
+					$params[ 'hash' ] = sha1(date('U'));
+					break;
+			}
 
-        // make the request
-        $args = array(
-            'method'    => $method,
-            'body'      => $params,
-            'headers'   => $headers,
-            'sslverify' => true,
-        );
+			// make the request
+			$args = array(
+				'method' => $method,
+				'body' => $params,
+				'headers' => $headers,
+				'sslverify' => true,
+			);
 
-        // make the remote request
-        $result = wp_remote_request($url, $args);
-        if (!is_wp_error($result)):
-            return $result['body'];
-        else:
-            return $result->get_error_message();
-        endif;
-    }
+			// make the remote request
+			$result = wp_remote_request($url, $args);
+			if (!is_wp_error($result)):
+				return $result[ 'body' ];
+			else:
+				return $result->get_error_message();
+			endif;
+		}
 
-    /**
-     * Get account associated lists.
-     *
-     * @return	array
-     *
-     * @since	0.1
-     */
-    public function get_lists()
-    {
-        $results = array();
+		/**
+		 * Get account associated lists.
+		 *
+		 * @return    array
+		 *
+		 * @since    0.1
+		 */
+		public function get_lists()
+		{
+			$results = array();
 
-        $lists_json = $this->api_call('lists', array(), 'GET');
-        $lists_arr = json_decode($lists_json, true);
-        if (isset($lists_arr['items']) && !empty($lists_arr['items'])):
-            $results = $lists_arr['items'];
-        endif;
+			$lists_json = $this->api_call('lists', array(), 'GET');
+			$lists_arr = json_decode($lists_json, true);
+			if (isset($lists_arr[ 'items' ]) && !empty($lists_arr[ 'items' ])):
+				$results = $lists_arr[ 'items' ];
+			endif;
 
-        return $results;
-    }
+			return $results;
+		}
 
-    /**
-     * Handle add list ajax post.
-     *
-     * @return	string	json
-     *
-     * @since	0.1
-     */
-    public function add_list()
-    {
-        $response = array();
+		/**
+		 * Handle add list ajax post.
+		 *
+		 * @return    string    json
+		 *
+		 * @since    0.1
+		 */
+		public function add_list()
+		{
+			$response = array();
 
-        $name = isset($_POST['name']) ? $_POST['name'] : null;
-        $email = isset($_POST['email']) ? $_POST['email'] : null;
+			$name = isset($_POST[ 'name' ]) ? $_POST[ 'name' ] : null;
+			$email = isset($_POST[ 'email' ]) ? $_POST[ 'email' ] : null;
 
-        $list_addresses = $_POST['addresses'];
+			$list_addresses = $_POST[ 'addresses' ];
 
-        if (!empty($list_addresses)):
-            foreach ($list_addresses as $address => $val):
-                $response[] = $this->api_call(
-                    "lists/{$address}/members",
-                    array(
-                        'address' => $email,
-                        'name'    => $name,
-                    )
-                );
-            endforeach;
+			if (!empty($list_addresses)):
+				foreach ($list_addresses as $address => $val):
+					$response[] = $this->api_call(
+						"lists/{$address}/members",
+						array(
+							'address' => $email,
+							'name' => $name,
+						)
+					);
+				endforeach;
 
-            echo json_encode(array('status' => 200, 'message' => 'Thank you!'));
-        else:
-            echo json_encode(array('status' => 500, 'message' => 'Uh oh. We weren\'t able to add you to the list'.count($list_addresses) ? 's.' : '. Please try again.'));
-        endif;
+				echo json_encode(array('status' => 200, 'message' => 'Thank you!'));
+			else:
+				echo json_encode(array(
+					'status' => 500,
+					'message' => 'Uh oh. We weren\'t able to add you to the list' . count($list_addresses) ? 's.' : '. Please try again.'
+				));
+			endif;
 
-        wp_die();
-    }
+			wp_die();
+		}
 
-    /**
-     * Frontend List Form.
-     *
-     * @param	string	$list_address	Mailgun address list id
-     * @param	array	$args			widget arguments
-     * @param	array	$instance		widget instance params
-     *
-     * @since	0.1
-     */
-    public function list_form($list_address, $args = array(), $instance = array())
-    {
-        $widget_class_id = "mailgun-list-widget-{$args['widget_id']}";
-        $form_class_id = "list-form-{$args['widget_id']}";
+		/**
+		 * Frontend List Form.
+		 *
+		 * @param    string $list_address Mailgun address list id
+		 * @param    array  $args         widget arguments
+		 * @param    array  $instance     widget instance params
+		 *
+		 * @since    0.1
+		 */
+		public function list_form($list_address, $args = array(), $instance = array())
+		{
+			$widget_class_id = "mailgun-list-widget-{$args['widget_id']}";
+			$form_class_id = "list-form-{$args['widget_id']}";
 
-        // List addresses from the plugin config
-        $list_addresses = array_map('trim', explode(',', $list_address));
+			// List addresses from the plugin config
+			$list_addresses = array_map('trim', explode(',', $list_address));
 
-        // All list info from the API; used for list info when more than one list is available to subscribe to
-        $all_list_addresses = $this->get_lists();
-?>
-        <div class="mailgun-list-widget-front <?php echo $widget_class_id; ?> widget">
-            <form class="list-form <?php echo $form_class_id; ?>">
-                <div class="mailgun-list-widget-inputs">
-                    <?php if (isset($args['list_title'])): ?>
-                        <div class="mailgun-list-title">
-                            <h4 class="widget-title">
-                                <span><?php echo $args['list_title']; ?></span>
-                            </h4>
-                        </div>
-                    <?php endif; ?>
-                    <?php if (isset($args['list_description'])): ?>
-                        <div class="mailgun-list-description">
-                            <p class="widget-description">
-                                <span><?php echo $args['list_description']; ?></span>
-                            </p>
-                        </div>
-                    <?php endif; ?>
-                    <?php if (isset($args['collect_name']) && intval($args['collect_name']) === 1): ?>
-                        <p class="mailgun-list-widget-name">
-                            <strong>Name:</strong>
-                            <input type="text" name="name" />
-                        </p>
-                    <?php endif; ?>
-                    <p class="mailgun-list-widget-email">
-                        <strong>Email:</strong>
-                        <input type="text" name="email" />
-                    </p>
-                </div>
+			// All list info from the API; used for list info when more than one list is available to subscribe to
+			$all_list_addresses = $this->get_lists();
+		?>
+			<div class="mailgun-list-widget-front <?php echo $widget_class_id; ?> widget">
+				<form class="list-form <?php echo $form_class_id; ?>">
+					<div class="mailgun-list-widget-inputs">
+						<?php if (isset($args[ 'list_title' ])): ?>
+							<div class="mailgun-list-title">
+								<h4 class="widget-title">
+									<span><?php echo $args[ 'list_title' ]; ?></span>
+								</h4>
+							</div>
+						<?php endif; ?>
+						<?php if (isset($args[ 'list_description' ])): ?>
+							<div class="mailgun-list-description">
+								<p class="widget-description">
+									<span><?php echo $args[ 'list_description' ]; ?></span>
+								</p>
+							</div>
+						<?php endif; ?>
+						<?php if (isset($args[ 'collect_name' ]) && intval($args[ 'collect_name' ]) === 1): ?>
+							<p class="mailgun-list-widget-name">
+								<strong>Name:</strong>
+								<input type="text" name="name"/>
+							</p>
+						<?php endif; ?>
+						<p class="mailgun-list-widget-email">
+							<strong>Email:</strong>
+							<input type="text" name="email"/>
+						</p>
+					</div>
 
-                <?php if (count($list_addresses) > '1'): ?>
-                    <ul class="mailgun-lists" style="list-style: none;">
-                        <?php
-							foreach ($all_list_addresses as $la):
-                            	if (!in_array($la['address'], $list_addresses)):
-            						continue;
-                            	endif;
-                        ?>
-                            <li>
-                                <input type="checkbox" class="mailgun-list-name" name="addresses[<?php echo $la['address']; ?>]" /> <?php echo $la['name']; ?>
-                            </li>
-                        <?php endforeach; ?>
-                    </ul>
-                <?php else: ?>
-                    <input type="hidden" name="addresses[<?php echo $list_addresses[0]; ?>]" value="on" />
-                <?php endif; ?>
+					<?php if (count($list_addresses) > '1'): ?>
+						<ul class="mailgun-lists" style="list-style: none;">
+							<?php
+								foreach ($all_list_addresses as $la):
+									if (!in_array($la[ 'address' ], $list_addresses)):
+										continue;
+									endif;
+							?>
+									<li>
+										<input type="checkbox" class="mailgun-list-name"
+											   name="addresses[<?php echo $la[ 'address' ]; ?>]"/> <?php echo $la[ 'name' ]; ?>
+									</li>
+							<?php endforeach; ?>
+						</ul>
+					<?php else: ?>
+						<input type="hidden" name="addresses[<?php echo $list_addresses[ 0 ]; ?>]" value="on"/>
+					<?php endif; ?>
 
-                <input class="mailgun-list-submit-button" data-form-id="<?php echo $form_class_id; ?>" type="button" value="Subscribe" />
-                <input type="hidden" name="mailgun-submission" value="1" />
+					<input class="mailgun-list-submit-button" data-form-id="<?php echo $form_class_id; ?>" type="button"
+						   value="Subscribe"/>
+					<input type="hidden" name="mailgun-submission" value="1"/>
 
-            </form>
-            <div class="widget-list-panel result-panel" style="display:none;">
-                <span>Thank you for subscribing!</span>
-            </div>
-        </div>
+				</form>
+				<div class="widget-list-panel result-panel" style="display:none;">
+					<span>Thank you for subscribing!</span>
+				</div>
+			</div>
 
-        <script>
-        jQuery(document).ready(function(){
+			<script>
+              jQuery(document).ready(function () {
 
-            jQuery('.mailgun-list-submit-button').on('click', function() {
+                jQuery('.mailgun-list-submit-button').on('click', function () {
 
-                var form_id = jQuery(this).data('form-id');
+                  var form_id = jQuery(this).data('form-id')
 
-                if(jQuery('.mailgun-list-name').length > 0 && jQuery('.'+form_id+' .mailgun-list-name:checked').length < 1) {
-                    alert('Please select a list to subscribe to.');
-                    return;
-                }
+                  if (jQuery('.mailgun-list-name').length > 0 && jQuery('.' + form_id + ' .mailgun-list-name:checked').length < 1) {
+                    alert('Please select a list to subscribe to.')
+                    return
+                  }
 
-                if(jQuery('.'+form_id+' .mailgun-list-widget-name input') && jQuery('.'+form_id+' .mailgun-list-widget-name input').val() === '') {
-                    alert('Please enter your subscription name.');
-                    return;
-                }
+                  if (jQuery('.' + form_id + ' .mailgun-list-widget-name input') && jQuery('.' + form_id + ' .mailgun-list-widget-name input').val() === '') {
+                    alert('Please enter your subscription name.')
+                    return
+                  }
 
-                if(jQuery('.'+form_id+' .mailgun-list-widget-email input').val() === '') {
-                    alert('Please enter your subscription email.');
-                    return;
-                }
+                  if (jQuery('.' + form_id + ' .mailgun-list-widget-email input').val() === '') {
+                    alert('Please enter your subscription email.')
+                    return
+                  }
 
-                jQuery.ajax({
+                  jQuery.ajax({
                     url: '<?php echo admin_url('admin-ajax.php?action=add_list'); ?>',
-                    action:'add_list',
+                    action: 'add_list',
                     type: 'post',
                     dataType: 'json',
-                    data: jQuery('.'+form_id+'').serialize(),
-                    success: function(data) {
+                    data: jQuery('.' + form_id + '').serialize(),
+                    success: function (data) {
 
-                        data_msg = data.message;
-                        already_exists = false;
-                        if(data_msg !== undefined){
-                            already_exists = data_msg.indexOf('Address already exists') > -1;
-                        }
+                      data_msg = data.message
+                      already_exists = false
+                      if (data_msg !== undefined) {
+                        already_exists = data_msg.indexOf('Address already exists') > -1
+                      }
 
-                        // success
-                        if((data.status === 200)) {
-                            jQuery('.<?php echo $widget_class_id; ?> .widget-list-panel').css('display', 'none');
-                            jQuery('.<?php echo $widget_class_id; ?> .list-form').css('display', 'none');
-                            jQuery('.<?php echo $widget_class_id; ?> .result-panel').css('display', 'block');
+                      // success
+                      if ((data.status === 200)) {
+                        jQuery('.<?php echo $widget_class_id; ?> .widget-list-panel').css('display', 'none')
+                        jQuery('.<?php echo $widget_class_id; ?> .list-form').css('display', 'none')
+                        jQuery('.<?php echo $widget_class_id; ?> .result-panel').css('display', 'block')
                         // error
-                        } else {
-                            alert(data_msg);
-                        }
+                      } else {
+                        alert(data_msg)
+                      }
                     }
-                });
-            });
-        });
-        </script>
+                  })
+                })
+              })
+			</script>
 
-<?php
-    }
+			<?php
+		}
 
-    /**
-     * Initialize List Form.
-     *
-     * @param	array	$atts	Form attributes
-     *
-     * @return	string
-     *
-     * @since	0.1
-     */
-    public function build_list_form($atts)
-    {
-        if (isset($atts['id']) && $atts['id'] != ''):
-            $args['widget_id'] = md5(rand(10000, 99999) + $atts['id']);
+		/**
+		 * Initialize List Form.
+		 *
+		 * @param    array $atts Form attributes
+		 *
+		 * @return    string
+		 *
+		 * @since    0.1
+		 */
+		public function build_list_form($atts)
+		{
+			if (isset($atts[ 'id' ]) && $atts[ 'id' ] != ''):
+				$args[ 'widget_id' ] = md5(rand(10000, 99999) + $atts[ 'id' ]);
 
-            if (isset($atts['collect_name'])):
-                $args['collect_name'] = true;
-            endif;
+				if (isset($atts[ 'collect_name' ])):
+					$args[ 'collect_name' ] = true;
+				endif;
 
-            if (isset($atts['title'])):
-                $args['list_title'] = $atts['title'];
-            endif;
+				if (isset($atts[ 'title' ])):
+					$args[ 'list_title' ] = $atts[ 'title' ];
+				endif;
 
-            if (isset($atts['description'])):
-                $args['list_description'] = $atts['description'];
-            endif;
+				if (isset($atts[ 'description' ])):
+					$args[ 'list_description' ] = $atts[ 'description' ];
+				endif;
 
-            ob_start();
-            $this->list_form($atts['id'], $args);
-            $output_string = ob_get_contents();
-            ob_end_clean();
+				ob_start();
+				$this->list_form($atts[ 'id' ], $args);
+				$output_string = ob_get_contents();
+				ob_end_clean();
 
-            return $output_string;
-        else:
-?>
-            <span>Mailgun list ID needed to render form!</span>
-            <br />
-            <strong>Example :</strong> [mailgun id="[your list id]"]
-<?php
+				return $output_string;
+			else:
+				?>
+				<span>Mailgun list ID needed to render form!</span>
+				<br/>
+				<strong>Example :</strong> [mailgun id="[your list id]"]
+			<?php
+			endif;
+		}
+
+		/**
+		 * Initialize List Widget.
+		 *
+		 * @since    0.1
+		 */
+		public function load_list_widget()
+		{
+			register_widget('list_widget');
+			add_shortcode('mailgun', array(&$this, 'build_list_form'));
+		}
+	}
+
+	$mailgun = new Mailgun();
+
+	if (@include dirname(__FILE__) . '/includes/widget.php'):
+		add_action('widgets_init', array(&$mailgun, 'load_list_widget'));
+		add_action('wp_ajax_nopriv_add_list', array(&$mailgun, 'add_list'));
+		add_action('wp_ajax_add_list', array(&$mailgun, 'add_list'));
+	endif;
+
+	if (is_admin()):
+		if (@include dirname(__FILE__) . '/includes/admin.php'):
+			$mailgunAdmin = new MailgunAdmin();
+		else:
+			Mailgun::deactivate_and_die(dirname(__FILE__) . '/includes/admin.php');
 		endif;
-    }
-
-    /**
-     * Initialize List Widget.
-     *
-     * @since	0.1
-     */
-    public function load_list_widget()
-    {
-        register_widget('list_widget');
-        add_shortcode('mailgun', array(&$this, 'build_list_form'));
-    }
-}
-
-$mailgun = new Mailgun();
-
-if (@include dirname(__FILE__).'/includes/widget.php'):
-    add_action('widgets_init', array(&$mailgun, 'load_list_widget'));
-    add_action('wp_ajax_nopriv_add_list', array(&$mailgun, 'add_list'));
-    add_action('wp_ajax_add_list', array(&$mailgun, 'add_list'));
-endif;
-
-if (is_admin()):
-    if (@include dirname(__FILE__).'/includes/admin.php'):
-        $mailgunAdmin = new MailgunAdmin();
-    else:
-        Mailgun::deactivate_and_die(dirname(__FILE__).'/includes/admin.php');
-    endif;
-endif;
+	endif;

--- a/mailgun.php
+++ b/mailgun.php
@@ -4,7 +4,7 @@
  * Plugin Name:  Mailgun
  * Plugin URI:   http://wordpress.org/extend/plugins/mailgun/
  * Description:  Mailgun integration for WordPress
- * Version:      1.5.14
+ * Version:      1.6
  * Author:       Mailgun
  * Author URI:   http://www.mailgun.com/
  * License:      GPLv2 or later
@@ -55,23 +55,23 @@ class Mailgun
         // Mailgun SMTP servers
         // When using SMTP, we also need to inject a `wp_mail` filter to make "from" settings
         // work properly. Fixes issues with 1.5.7+
-        if ($this->get_option('useAPI') || (defined('MAILGUN_USEAPI') && MAILGUN_USEAPI)) {
-            if (!function_exists('wp_mail')) {
-                if (!include dirname(__FILE__).'/includes/wp-mail-api.php') {
+        if ($this->get_option('useAPI') || (defined('MAILGUN_USEAPI') && MAILGUN_USEAPI)):
+            if (!function_exists('wp_mail')):
+                if (!include dirname(__FILE__).'/includes/wp-mail-api.php'):
                     self::deactivate_and_die(dirname(__FILE__).'/includes/wp-mail-api.php');
-                }
-            }
-        } else {
+                endif;
+            endif;
+        else:
             // Using SMTP, include the SMTP filter
-            if (!function_exists('mg_smtp_mail_filter')) {
-                if (!include dirname(__FILE__).'/includes/wp-mail-smtp.php') {
+            if (!function_exists('mg_smtp_mail_filter')):
+                if (!include dirname(__FILE__).'/includes/wp-mail-smtp.php'):
                     self::deactivate_and_die(dirname(__FILE__).'/includes/wp-mail-smtp.php');
-                }
-            }
+                endif;
+            endif;
             add_filter('wp_mail', 'mg_smtp_mail_filter');
             add_action('phpmailer_init', array(&$this, 'phpmailer_init'));
             add_action('wp_mail_failed', 'wp_mail_failed');
-        }
+        endif;
     }
 
     /**
@@ -87,14 +87,14 @@ class Mailgun
      */
     public function get_option($option, $options = null, $default = false)
     {
-        if (is_null($options)) {
+        if (is_null($options)):
             $options = &$this->options;
-        }
-        if (isset($options[$option])) {
+        endif;
+        if (isset($options[$option])):
             return $options[$option];
-        } else {
+        else:
             return $default;
-        }
+        endif;
     }
 
     /**
@@ -122,13 +122,15 @@ class Mailgun
 
         $phpmailer->Mailer = 'smtp';
         $phpmailer->Host = $smtp_endpoint;
-        if ( 'ssl' === $sectype ) {
+
+        if ( 'ssl' === $sectype ):
             // For SSL-only connections, use 465
             $phpmailer->Port = 465;
-        } else {
+        else:
             // Otherwise, use 587.
             $phpmailer->Port = 587;
-        }
+        endif;
+
         $phpmailer->SMTPAuth = true;
         $phpmailer->Username = $username;
         $phpmailer->Password = $password;
@@ -156,9 +158,9 @@ class Mailgun
     {
         load_plugin_textdomain('mailgun', false, 'mailgun/languages');
         $message = sprintf(__('Mailgun has been automatically deactivated because the file <strong>%s</strong> is missing. Please reinstall the plugin and reactivate.'), $file);
-        if (!function_exists('deactivate_plugins')) {
+        if (!function_exists('deactivate_plugins')):
             include ABSPATH.'wp-admin/includes/plugin.php';
-        }
+        endif;
         deactivate_plugins(__FILE__);
         wp_die($message);
     }
@@ -216,11 +218,11 @@ class Mailgun
 
         // make the remote request
         $result = wp_remote_request($url, $args);
-        if (!is_wp_error($result)) {
+        if (!is_wp_error($result)):
             return $result['body'];
-        } else {
+        else:
             return $result->get_error_message();
-        }
+        endif;
     }
 
     /**
@@ -236,9 +238,9 @@ class Mailgun
 
         $lists_json = $this->api_call('lists', array(), 'GET');
         $lists_arr = json_decode($lists_json, true);
-        if (isset($lists_arr['items']) && !empty($lists_arr['items'])) {
+        if (isset($lists_arr['items']) && !empty($lists_arr['items'])):
             $results = $lists_arr['items'];
-        }
+        endif;
 
         return $results;
     }
@@ -259,8 +261,8 @@ class Mailgun
 
         $list_addresses = $_POST['addresses'];
 
-        if (!empty($list_addresses)) {
-            foreach ($list_addresses as $address => $val) {
+        if (!empty($list_addresses)):
+            foreach ($list_addresses as $address => $val):
                 $response[] = $this->api_call(
                     "lists/{$address}/members",
                     array(
@@ -268,12 +270,12 @@ class Mailgun
                         'name'    => $name,
                     )
                 );
-            }
+            endforeach;
 
             echo json_encode(array('status' => 200, 'message' => 'Thank you!'));
-        } else {
+        else:
             echo json_encode(array('status' => 500, 'message' => 'Uh oh. We weren\'t able to add you to the list'.count($list_addresses) ? 's.' : '. Please try again.'));
-        }
+        endif;
 
         wp_die();
     }
@@ -296,25 +298,26 @@ class Mailgun
         $list_addresses = array_map('trim', explode(',', $list_address));
 
         // All list info from the API; used for list info when more than one list is available to subscribe to
-        $all_list_addresses = $this->get_lists(); ?>
+        $all_list_addresses = $this->get_lists();
+?>
         <div class="mailgun-list-widget-front <?php echo $widget_class_id; ?> widget">
             <form class="list-form <?php echo $form_class_id; ?>">
                 <div class="mailgun-list-widget-inputs">
-                    <?php if (isset($args['list_title'])) : ?>
+                    <?php if (isset($args['list_title'])): ?>
                         <div class="mailgun-list-title">
                             <h4 class="widget-title">
                                 <span><?php echo $args['list_title']; ?></span>
                             </h4>
                         </div>
                     <?php endif; ?>
-                    <?php if (isset($args['list_description'])) : ?>
+                    <?php if (isset($args['list_description'])): ?>
                         <div class="mailgun-list-description">
                             <p class="widget-description">
                                 <span><?php echo $args['list_description']; ?></span>
                             </p>
                         </div>
                     <?php endif; ?>
-                    <?php if (isset($args['collect_name']) && intval($args['collect_name']) === 1) : ?>
+                    <?php if (isset($args['collect_name']) && intval($args['collect_name']) === 1): ?>
                         <p class="mailgun-list-widget-name">
                             <strong>Name:</strong>
                             <input type="text" name="name" />
@@ -326,18 +329,20 @@ class Mailgun
                     </p>
                 </div>
 
-                <?php if (count($list_addresses) > 1) : ?>
+                <?php if (count($list_addresses) > '1'): ?>
                     <ul class="mailgun-lists" style="list-style: none;">
-                        <?php foreach ($all_list_addresses as $la) : ?>
-                            <?php if (!in_array($la['address'], $list_addresses)) {
-            continue;
-        } ?>
+                        <?php
+							foreach ($all_list_addresses as $la):
+                            	if (!in_array($la['address'], $list_addresses)):
+            						continue;
+                            	endif;
+                        ?>
                             <li>
                                 <input type="checkbox" class="mailgun-list-name" name="addresses[<?php echo $la['address']; ?>]" /> <?php echo $la['name']; ?>
                             </li>
                         <?php endforeach; ?>
                     </ul>
-                <?php else : ?>
+                <?php else: ?>
                     <input type="hidden" name="addresses[<?php echo $list_addresses[0]; ?>]" value="on" />
                 <?php endif; ?>
 
@@ -351,7 +356,6 @@ class Mailgun
         </div>
 
         <script>
-
         jQuery(document).ready(function(){
 
             jQuery('.mailgun-list-submit-button').on('click', function() {
@@ -400,11 +404,9 @@ class Mailgun
                 });
             });
         });
-
         </script>
 
-        <?php
-
+<?php
     }
 
     /**
@@ -418,20 +420,20 @@ class Mailgun
      */
     public function build_list_form($atts)
     {
-        if (isset($atts['id']) && $atts['id'] != '') {
+        if (isset($atts['id']) && $atts['id'] != ''):
             $args['widget_id'] = md5(rand(10000, 99999) + $atts['id']);
 
-            if (isset($atts['collect_name'])) {
+            if (isset($atts['collect_name'])):
                 $args['collect_name'] = true;
-            }
+            endif;
 
-            if (isset($atts['title'])) {
+            if (isset($atts['title'])):
                 $args['list_title'] = $atts['title'];
-            }
+            endif;
 
-            if (isset($atts['description'])) {
+            if (isset($atts['description'])):
                 $args['list_description'] = $atts['description'];
-            }
+            endif;
 
             ob_start();
             $this->list_form($atts['id'], $args);
@@ -439,14 +441,13 @@ class Mailgun
             ob_end_clean();
 
             return $output_string;
-        } else {
-            ?>
+        else:
+?>
             <span>Mailgun list ID needed to render form!</span>
             <br />
             <strong>Example :</strong> [mailgun id="[your list id]"]
-            <?php
-
-        }
+<?php
+		endif;
     }
 
     /**
@@ -463,16 +464,16 @@ class Mailgun
 
 $mailgun = new Mailgun();
 
-if (@include dirname(__FILE__).'/includes/widget.php') {
+if (@include dirname(__FILE__).'/includes/widget.php'):
     add_action('widgets_init', array(&$mailgun, 'load_list_widget'));
     add_action('wp_ajax_nopriv_add_list', array(&$mailgun, 'add_list'));
     add_action('wp_ajax_add_list', array(&$mailgun, 'add_list'));
-}
+endif;
 
-if (is_admin()) {
-    if (@include dirname(__FILE__).'/includes/admin.php') {
+if (is_admin()):
+    if (@include dirname(__FILE__).'/includes/admin.php'):
         $mailgunAdmin = new MailgunAdmin();
-    } else {
+    else:
         Mailgun::deactivate_and_die(dirname(__FILE__).'/includes/admin.php');
-    }
-}
+    endif;
+endif;

--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Contributors: Mailgun, sivel, lookahead.io, m35dev
 Tags: mailgun, smtp, http, api, mail, email
 Requires at least: 3.3
 Tested up to: 4.9.8
-Stable tag: 1.5.14
+Stable tag: 1.6
 License: GPLv2 or later
 
 
@@ -127,6 +127,12 @@ MAILGUN_FROM_ADDRESS Type: string
 
 
 == Changelog ==
+
+= 1.6 (2018-9-21): =
+- Refactor admin notifications
+- Enable Settings page for all WordPress install types
+- Enable Test Configuration for all WordPress install types
+- Test plugin up to WordPress 4.9.8.
 
 = 1.5.14 (2018-09-11): =
 - Force SSL-secured SMTP connections to use port 465 (SMTPS) to connect, 587 for plain and TLS

--- a/readme.txt
+++ b/readme.txt
@@ -54,7 +54,8 @@ Yes, using the following constants that can be placed in wp-config.php:
 
 `
 MAILGUN_REGION       Type: string   Choices: 'us' or 'eu'
-MAILGUN_USEAPI       Type: boolean
+     ex. define('MAILGUN_REGION', 'us');
+MAILGUN_USEAPI       Type: boolean  Choices: '0' or '1' (0 = false/no)
 MAILGUN_APIKEY       Type: string
 MAILGUN_DOMAIN       Type: string
 MAILGUN_USERNAME     Type: string


### PR DESCRIPTION
Refactor and clean up:

1. Combine admin notifications
2. Add close button to notifications
3. Add multisite check for settings page
4. Enable settings page and test configuration for all WP install types

@pirogoeth take a good look at this one, if you can. With the changes made, I'd like to be sure nothing got missed.
I've tested using both the wp-config constants and the settings page.