### PR TITLE
non successful connection error message

### DIFF
--- a/includes/admin.php
+++ b/includes/admin.php
@@ -470,7 +470,7 @@
 				)
 				);
 			else:
-				// Error message will always be returned if case of failure, if not - connection wasn't successful
+				// Error message will always be returned in case of failure, if not - connection wasn't successful
 				$error_msg = $error_msg ? $error_msg : "Can't connect to Mailgun";
 
 				die(

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -470,6 +470,9 @@
 				)
 				);
 			else:
+				// Error message will always be returned if case of failure, if not - connection wasn't successful
+				$error_msg = $error_msg ? $error_msg : "Can't connect to Mailgun";
+
 				die(
 				json_encode(
 					array(


### PR DESCRIPTION
https://github.com/mailgun/wordpress-plugin/issues/57

Since error message is always returned in case of failure, and when we don't have a message - it means there was no connection.