### PR TITLE
Put $mailgun in global scope for later use

### DIFF
--- a/mailgun.php
+++ b/mailgun.php
@@ -506,6 +506,7 @@ class Mailgun
     }
 }
 
+global $mailgun;
 $mailgun = new Mailgun();
 
 if (@include __DIR__ . '/includes/widget.php') {


### PR DESCRIPTION
Without it, `includes/options-page.php` will choke on [line 53](https://github.com/mailgun/wordpress-plugin/blob/master/includes/options-page.php#L53) with error `Call to a member function getAssetsPath() on null`.