### PR TITLE
Respect WordPress core wp_mail filter

### DIFF
--- a/includes/wp-mail-api.php
+++ b/includes/wp-mail-api.php
@@ -126,6 +126,37 @@ if (!function_exists('wp_mail')) {
             error_log('[Mailgun] No region configuration was found! Defaulting to US region.');
             $region = 'us';
         }
+        
+        // Respect WordPress core filters
+        $atts = apply_filters( 'wp_mail', compact( 'to', 'subject', 'message', 'headers', 'attachments' ) );
+
+        if ( isset( $atts['to'] ) ) {
+            $to = $atts['to'];
+        }
+
+        if ( ! is_array( $to ) ) {
+            $to = explode( ',', $to );
+        }
+
+        if ( isset( $atts['subject'] ) ) {
+            $subject = $atts['subject'];
+        }
+
+        if ( isset( $atts['message'] ) ) {
+            $message = $atts['message'];
+        }
+
+        if ( isset( $atts['headers'] ) ) {
+            $headers = $atts['headers'];
+        }
+
+        if ( isset( $atts['attachments'] ) ) {
+            $attachments = $atts['attachments'];
+        }
+
+        if (!is_array($attachments)) {
+            $attachments = explode("\n", str_replace("\r\n", "\n", $attachments));
+        }
 
         if (!is_array($attachments)) {
             $attachments = explode("\n", str_replace("\r\n", "\n", $attachments));


### PR DESCRIPTION
Many plugins rely on the `wp_mail` filter to do certain things. Mailgun plugin does not respect that filter currently, so some functionalities are broken. For example, our agency's helper plugin allows sending emails only to allow listed addresses on specific occurrences. The check is done in `wp_mail` filter.

This PR adds the `wp_mail` filter in order to other plugin functionalities to work.