### PR TITLE
Fix warnings due to defualt property not set on save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 Changelog
 =========
+= 1.9.7 (2024-01-03): =
+- Ensure defaults are always set to remove warnings in PHP 8.1+
+
 1.9.6 (2023-09-10)
 - Added typehints to methods 
 - Added code for making plugin WP VIP GO compatible for the `From mail`

--- a/includes/admin.php
+++ b/includes/admin.php
@@ -43,11 +43,13 @@ class MailgunAdmin extends Mailgun
     {
         parent::__construct();
 
+        $this->init();
+
         // Load localizations if available
         load_plugin_textdomain('mailgun', false, 'mailgun/languages');
 
         // Activation hook
-        register_activation_hook($this->plugin_file, [&$this, 'init']);
+        register_activation_hook($this->plugin_file, [&$this, 'activation']);
 
         // Hook into admin_init and register settings and potentially register an admin_notice
         add_action('admin_init', [&$this, 'admin_init']);
@@ -59,8 +61,22 @@ class MailgunAdmin extends Mailgun
         add_action('wp_ajax_mailgun-test', [&$this, 'ajax_send_test']);
     }
 
+	/**
+	 * Adds the default options during plugin activation.
+	 *
+	 * @return    void
+	 *
+	 */
+	public function activation() {
+		if (!$this->options) {
+			$this->options = $this->defaults;
+			add_option('mailgun', $this->options);
+		}
+    }
+
+
     /**
-     * Initialize the default options during plugin activation.
+     * Initialize the default property.
      *
      * @return    void
      *
@@ -90,10 +106,7 @@ class MailgunAdmin extends Mailgun
             'override-from' => '0',
             'tag' => $sitename,
         );
-        if (!$this->options) {
-            $this->options = $this->defaults;
-            add_option('mailgun', $this->options);
-        }
+
     }
 
     /**

--- a/mailgun.php
+++ b/mailgun.php
@@ -3,8 +3,9 @@
  * Plugin Name:  Mailgun
  * Plugin URI:   http://wordpress.org/extend/plugins/mailgun/
  * Description:  Mailgun integration for WordPress
- * Version:      1.9.6
- * Tested up to: 6.3.1
+ * Version:      1.9.7
+ * Requires PHP: 7.4
+ * Requires at least: 4.4
  * Author:       Mailgun
  * Author URI:   http://www.mailgun.com/
  * License:      GPLv2 or later

--- a/readme.md
+++ b/readme.md
@@ -1,12 +1,10 @@
 Mailgun for WordPress
 =====================
 
-Contributors: mailgun, sivel, lookahead.io, m35dev
+Contributors: mailgun, sivel, lookahead.io, m35dev, alanfuller
 Tags: mailgun, smtp, http, api, mail, email
-Requires at least: 3.3
-Tested up to: 6.3.1
-Stable tag: 1.9.6
-Requires PHP: 7.4
+Tested up to: 6.4
+Stable tag: 1.9.7
 License: GPLv2 or later
 
 Easily send email from your WordPress site through Mailgun using the HTTP API or SMTP.
@@ -132,6 +130,8 @@ MAILGUN_TRACK_OPENS  Type: string Choices: 'yes' or 'no'
 
 
 == Changelog ==
+= 1.9.7 (2024-01-03): =
+- Ensure defaults are always set to remove warnings in PHP 8.1+
 
 = 1.9.6 (2023-09-10): =
 - Added typehints to methods

--- a/readme.txt
+++ b/readme.txt
@@ -1,12 +1,10 @@
 Mailgun for WordPress
 =====================
 
-Contributors: mailgun, sivel, lookahead.io, m35dev
+Contributors: mailgun, sivel, lookahead.io, m35dev, alanfuller
 Tags: mailgun, smtp, http, api, mail, email
-Requires at least: 4.4
-Tested up to: 6.3.1
-Stable tag: 1.9.6
-Requires PHP: 7.4
+Tested up to: 6.4
+Stable tag: 1.9.7
 License: GPLv2 or later
 
 Easily send email from your WordPress site through Mailgun using the HTTP API or SMTP.
@@ -130,6 +128,8 @@ MAILGUN_TRACK_OPENS  Type: string Choices: 'yes' or 'no'
 
 
 == Changelog ==
+= 1.9.7 (2024-01-03): =
+- Ensure defaults are always set to remove warnings in PHP 8.1+
 
 = 1.9.6 (2023-09-10): =
 - Added typehints to methods


### PR DESCRIPTION
This update revises the Mailgun plugin's activation behaviour to ensure default options are always set, preventing warnings in PHP 8.1+. Additionally, the minimum required and tested WordPress versions, PHP version, and contributor list were updated. A version bump to 1.9.7 was applied.  The headersbetween plugin header and readme were corrected to reflect current wp org directory operation.