### PR TITLE
Fix initial send failures being ignored if fallback is disabled

### DIFF
--- a/includes/wp-mail-api.php
+++ b/includes/wp-mail-api.php
@@ -495,248 +495,248 @@ if ( ! function_exists('wp_mail')) {
         }
 
         // Email Fallback
+        if (!$isFallbackNeeded) return true;
+
         $isFallbackEnabled = get_option('email_fallback') ?: 'no';
-        if ($isFallbackNeeded && $isFallbackEnabled === 'yes') {
-            global $phpmailer;
+        if (!($isFallbackEnabled === 'yes')) return false;
 
-            // (Re)create it, if it's gone missing.
-            if ( ! ( $phpmailer instanceof PHPMailer\PHPMailer\PHPMailer )) {
-                require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
-                require_once ABSPATH . WPINC . '/PHPMailer/SMTP.php';
-                require_once ABSPATH . WPINC . '/PHPMailer/Exception.php';
-                $phpmailer = new PHPMailer\PHPMailer\PHPMailer(true);
+        global $phpmailer;
 
-                $phpmailer::$validator = static function ( $email ) {
-                    return (bool) is_email($email);
-                };
-            }
+        // (Re)create it, if it's gone missing.
+        if ( ! ( $phpmailer instanceof PHPMailer\PHPMailer\PHPMailer )) {
+            require_once ABSPATH . WPINC . '/PHPMailer/PHPMailer.php';
+            require_once ABSPATH . WPINC . '/PHPMailer/SMTP.php';
+            require_once ABSPATH . WPINC . '/PHPMailer/Exception.php';
+            $phpmailer = new PHPMailer\PHPMailer\PHPMailer(true);
 
-            // Empty out the values that may be set.
-            $phpmailer->clearAllRecipients();
-            $phpmailer->clearAttachments();
-            $phpmailer->clearCustomHeaders();
-            $phpmailer->clearReplyTos();
-            $phpmailer->Body    = '';
-            $phpmailer->AltBody = '';
+            $phpmailer::$validator = static function ( $email ) {
+                return (bool) is_email($email);
+            };
+        }
 
-            // Set "From" name and email.
+        // Empty out the values that may be set.
+        $phpmailer->clearAllRecipients();
+        $phpmailer->clearAttachments();
+        $phpmailer->clearCustomHeaders();
+        $phpmailer->clearReplyTos();
+        $phpmailer->Body    = '';
+        $phpmailer->AltBody = '';
 
-            // If we don't have a name from the input headers.
-            if ( ! isset($from_name)) {
-                $from_name = 'WordPress';
-            }
+        // Set "From" name and email.
 
-            /*
-             * If we don't have an email from the input headers, default to wordpress@$sitename
-             * Some hosts will block outgoing mail from this address if it doesn't exist,
-             * but there's no easy alternative. Defaulting to admin_email might appear to be
-             * another option, but some hosts may refuse to relay mail from an unknown domain.
-             * See https://core.trac.wordpress.org/ticket/5007.
-             */
-            if ( ! isset($from_email)) {
-                // Get the site domain and get rid of www.
-                $sitename   = wp_parse_url(network_home_url(), PHP_URL_HOST);
-                $from_email = 'wordpress@';
+        // If we don't have a name from the input headers.
+        if ( ! isset($from_name)) {
+            $from_name = 'WordPress';
+        }
 
-                if (null !== $sitename) {
-                    if (str_starts_with($sitename, 'www.')) {
-                        $sitename = substr($sitename, 4);
-                    }
+        /*
+         * If we don't have an email from the input headers, default to wordpress@$sitename
+         * Some hosts will block outgoing mail from this address if it doesn't exist,
+         * but there's no easy alternative. Defaulting to admin_email might appear to be
+         * another option, but some hosts may refuse to relay mail from an unknown domain.
+         * See https://core.trac.wordpress.org/ticket/5007.
+         */
+        if ( ! isset($from_email)) {
+            // Get the site domain and get rid of www.
+            $sitename   = wp_parse_url(network_home_url(), PHP_URL_HOST);
+            $from_email = 'wordpress@';
 
-                    $from_email .= $sitename;
-                }
-            }
-
-            /**
-             * Filters the email address to send from.
-             *
-             * @param string $from_email Email address to send from.
-             * @since 2.2.0
-             */
-            $from_email = apply_filters('wp_mail_from', $from_email);
-
-            /**
-             * Filters the name to associate with the "from" email address.
-             *
-             * @param string $from_name Name associated with the "from" email address.
-             * @since 2.3.0
-             */
-            $from_name = apply_filters('wp_mail_from_name', $from_name);
-
-            try {
-                $phpmailer->setFrom($from_email, $from_name, false);
-            } catch (PHPMailer\PHPMailer\Exception $e) {
-                $mail_error_data                             = compact('to', 'subject', 'message', 'headers', 'attachments');
-                $mail_error_data['phpmailer_exception_code'] = $e->getCode();
-
-                /** This filter is documented in wp-includes/pluggable.php */
-                do_action('wp_mail_failed', new WP_Error('wp_mail_failed', $e->getMessage(), $mail_error_data));
-
-                return false;
-            }
-
-            // Set mail's subject and body.
-            $phpmailer->Subject = $subject;
-            $phpmailer->Body    = $message;
-
-            // Set destination addresses, using appropriate methods for handling addresses.
-            $address_headers = compact('to', 'cc', 'bcc', 'replyTo');
-
-            foreach ($address_headers as $address_header => $addresses) {
-                if (empty($addresses)) {
-                    continue;
+            if (null !== $sitename) {
+                if (str_starts_with($sitename, 'www.')) {
+                    $sitename = substr($sitename, 4);
                 }
 
-                foreach ( (array) $addresses as $address) {
-                    try {
-                        // Break $recipient into name and address parts if in the format "Foo <bar@baz.com>".
-                        $recipient_name = '';
-
-                        if (preg_match('/(.*)<(.+)>/', $address, $matches)) {
-                            if (count($matches) === 3) {
-                                $recipient_name = $matches[1];
-                                $address        = $matches[2];
-                            }
-                        }
-
-                        switch ($address_header) {
-                            case 'to':
-                                $phpmailer->addAddress($address, $recipient_name);
-                                break;
-                            case 'cc':
-                                $phpmailer->addCc($address, $recipient_name);
-                                break;
-                            case 'bcc':
-                                $phpmailer->addBcc($address, $recipient_name);
-                                break;
-                            case 'reply_to':
-                                $phpmailer->addReplyTo($address, $recipient_name);
-                                break;
-                        }
-                    } catch (PHPMailer\PHPMailer\Exception $e) {
-                        continue;
-                    }
-                }
-            }
-
-            // Set to use PHP's mail().
-            $phpmailer->isMail();
-
-            // Set Content-Type and charset.
-
-            // If we don't have a Content-Type from the input headers.
-            if ( ! isset($content_type)) {
-                $content_type = 'text/plain';
-            }
-
-            /**
-             * Filters the wp_mail() content type.
-             *
-             * @param string $content_type Default wp_mail() content type.
-             * @since 2.3.0
-             */
-            $content_type = apply_filters('wp_mail_content_type', $content_type);
-
-            $phpmailer->ContentType = $content_type;
-
-            // Set whether it's plaintext, depending on $content_type.
-            if ('text/html' === $content_type) {
-                $phpmailer->isHTML(true);
-            }
-
-            // If we don't have a charset from the input headers.
-            if ( ! isset($charset)) {
-                $charset = get_bloginfo('charset');
-            }
-
-            /**
-             * Filters the default wp_mail() charset.
-             *
-             * @param string $charset Default email charset.
-             * @since 2.3.0
-             */
-            $phpmailer->CharSet = apply_filters('wp_mail_charset', $charset);
-
-            // Set custom headers.
-            if ( ! empty($headers)) {
-                foreach ( (array) $headers as $name => $content) {
-                    // Only add custom headers not added automatically by PHPMailer.
-                    if ( ! in_array($name, array( 'MIME-Version', 'X-Mailer' ), true)) {
-                        try {
-                            $phpmailer->addCustomHeader(sprintf('%1$s: %2$s', $name, $content));
-                        } catch (PHPMailer\PHPMailer\Exception $e) {
-                            continue;
-                        }
-                    }
-                }
-
-                if (false !== stripos($content_type, 'multipart') && ! empty($boundary)) {
-                    $phpmailer->addCustomHeader(sprintf('Content-Type: %s; boundary="%s"', $content_type, $boundary));
-                }
-            }
-
-            if ( ! empty($attachments)) {
-                foreach ($attachments as $filename => $attachment) {
-                    $filename = is_string($filename) ? $filename : '';
-
-                    try {
-                        $phpmailer->addAttachment($attachment, $filename);
-                    } catch (PHPMailer\PHPMailer\Exception $e) {
-                        continue;
-                    }
-                }
-            }
-
-            /**
-             * Fires after PHPMailer is initialized.
-             *
-             * @param PHPMailer $phpmailer The PHPMailer instance (passed by reference).
-             * @since 2.2.0
-             */
-            do_action_ref_array('phpmailer_init', array( &$phpmailer ));
-
-            $mail_data = compact('to', 'subject', 'message', 'headers', 'attachments');
-
-            // Send!
-            try {
-                $send = $phpmailer->send();
-
-                /**
-                 * Fires after PHPMailer has successfully sent an email.
-                 * The firing of this action does not necessarily mean that the recipient(s) received the
-                 * email successfully. It only means that the `send` method above was able to
-                 * process the request without any errors.
-                 *
-                 * @param array $mail_data {
-                 *     An array containing the email recipient(s), subject, message, headers, and attachments.
-                 * @type string[] $to Email addresses to send message.
-                 * @type string $subject Email subject.
-                 * @type string $message Message contents.
-                 * @type string[] $headers Additional headers.
-                 * @type string[] $attachments Paths to files to attach.
-                 * }
-                 * @since 5.9.0
-                 */
-                do_action('wp_mail_succeeded', $mail_data);
-
-                return $send;
-            } catch (PHPMailer\PHPMailer\Exception $e) {
-                $mail_data['phpmailer_exception_code'] = $e->getCode();
-
-                /**
-                 * Fires after a PHPMailer\PHPMailer\Exception is caught.
-                 *
-                 * @param WP_Error $error A WP_Error object with the PHPMailer\PHPMailer\Exception message, and an array
-                 *                        containing the mail recipient, subject, message, headers, and attachments.
-                 * @since 4.4.0
-                 */
-                do_action('wp_mail_failed', new WP_Error('wp_mail_failed', $e->getMessage(), $mail_data));
-
-                return false;
+                $from_email .= $sitename;
             }
         }
 
-        return true;
+        /**
+         * Filters the email address to send from.
+         *
+         * @param string $from_email Email address to send from.
+         * @since 2.2.0
+         */
+        $from_email = apply_filters('wp_mail_from', $from_email);
+
+        /**
+         * Filters the name to associate with the "from" email address.
+         *
+         * @param string $from_name Name associated with the "from" email address.
+         * @since 2.3.0
+         */
+        $from_name = apply_filters('wp_mail_from_name', $from_name);
+
+        try {
+            $phpmailer->setFrom($from_email, $from_name, false);
+        } catch (PHPMailer\PHPMailer\Exception $e) {
+            $mail_error_data                             = compact('to', 'subject', 'message', 'headers', 'attachments');
+            $mail_error_data['phpmailer_exception_code'] = $e->getCode();
+
+            /** This filter is documented in wp-includes/pluggable.php */
+            do_action('wp_mail_failed', new WP_Error('wp_mail_failed', $e->getMessage(), $mail_error_data));
+
+            return false;
+        }
+
+        // Set mail's subject and body.
+        $phpmailer->Subject = $subject;
+        $phpmailer->Body    = $message;
+
+        // Set destination addresses, using appropriate methods for handling addresses.
+        $address_headers = compact('to', 'cc', 'bcc', 'replyTo');
+
+        foreach ($address_headers as $address_header => $addresses) {
+            if (empty($addresses)) {
+                continue;
+            }
+
+            foreach ( (array) $addresses as $address) {
+                try {
+                    // Break $recipient into name and address parts if in the format "Foo <bar@baz.com>".
+                    $recipient_name = '';
+
+                    if (preg_match('/(.*)<(.+)>/', $address, $matches)) {
+                        if (count($matches) === 3) {
+                            $recipient_name = $matches[1];
+                            $address        = $matches[2];
+                        }
+                    }
+
+                    switch ($address_header) {
+                        case 'to':
+                            $phpmailer->addAddress($address, $recipient_name);
+                            break;
+                        case 'cc':
+                            $phpmailer->addCc($address, $recipient_name);
+                            break;
+                        case 'bcc':
+                            $phpmailer->addBcc($address, $recipient_name);
+                            break;
+                        case 'reply_to':
+                            $phpmailer->addReplyTo($address, $recipient_name);
+                            break;
+                    }
+                } catch (PHPMailer\PHPMailer\Exception $e) {
+                    continue;
+                }
+            }
+        }
+
+        // Set to use PHP's mail().
+        $phpmailer->isMail();
+
+        // Set Content-Type and charset.
+
+        // If we don't have a Content-Type from the input headers.
+        if ( ! isset($content_type)) {
+            $content_type = 'text/plain';
+        }
+
+        /**
+         * Filters the wp_mail() content type.
+         *
+         * @param string $content_type Default wp_mail() content type.
+         * @since 2.3.0
+         */
+        $content_type = apply_filters('wp_mail_content_type', $content_type);
+
+        $phpmailer->ContentType = $content_type;
+
+        // Set whether it's plaintext, depending on $content_type.
+        if ('text/html' === $content_type) {
+            $phpmailer->isHTML(true);
+        }
+
+        // If we don't have a charset from the input headers.
+        if ( ! isset($charset)) {
+            $charset = get_bloginfo('charset');
+        }
+
+        /**
+         * Filters the default wp_mail() charset.
+         *
+         * @param string $charset Default email charset.
+         * @since 2.3.0
+         */
+        $phpmailer->CharSet = apply_filters('wp_mail_charset', $charset);
+
+        // Set custom headers.
+        if ( ! empty($headers)) {
+            foreach ( (array) $headers as $name => $content) {
+                // Only add custom headers not added automatically by PHPMailer.
+                if ( ! in_array($name, array( 'MIME-Version', 'X-Mailer' ), true)) {
+                    try {
+                        $phpmailer->addCustomHeader(sprintf('%1$s: %2$s', $name, $content));
+                    } catch (PHPMailer\PHPMailer\Exception $e) {
+                        continue;
+                    }
+                }
+            }
+
+            if (false !== stripos($content_type, 'multipart') && ! empty($boundary)) {
+                $phpmailer->addCustomHeader(sprintf('Content-Type: %s; boundary="%s"', $content_type, $boundary));
+            }
+        }
+
+        if ( ! empty($attachments)) {
+            foreach ($attachments as $filename => $attachment) {
+                $filename = is_string($filename) ? $filename : '';
+
+                try {
+                    $phpmailer->addAttachment($attachment, $filename);
+                } catch (PHPMailer\PHPMailer\Exception $e) {
+                    continue;
+                }
+            }
+        }
+
+        /**
+         * Fires after PHPMailer is initialized.
+         *
+         * @param PHPMailer $phpmailer The PHPMailer instance (passed by reference).
+         * @since 2.2.0
+         */
+        do_action_ref_array('phpmailer_init', array( &$phpmailer ));
+
+        $mail_data = compact('to', 'subject', 'message', 'headers', 'attachments');
+
+        // Send!
+        try {
+            $send = $phpmailer->send();
+
+            /**
+             * Fires after PHPMailer has successfully sent an email.
+             * The firing of this action does not necessarily mean that the recipient(s) received the
+             * email successfully. It only means that the `send` method above was able to
+             * process the request without any errors.
+             *
+             * @param array $mail_data {
+             *     An array containing the email recipient(s), subject, message, headers, and attachments.
+             * @type string[] $to Email addresses to send message.
+             * @type string $subject Email subject.
+             * @type string $message Message contents.
+             * @type string[] $headers Additional headers.
+             * @type string[] $attachments Paths to files to attach.
+             * }
+             * @since 5.9.0
+             */
+            do_action('wp_mail_succeeded', $mail_data);
+
+            return $send;
+        } catch (PHPMailer\PHPMailer\Exception $e) {
+            $mail_data['phpmailer_exception_code'] = $e->getCode();
+
+            /**
+             * Fires after a PHPMailer\PHPMailer\Exception is caught.
+             *
+             * @param WP_Error $error A WP_Error object with the PHPMailer\PHPMailer\Exception message, and an array
+             *                        containing the mail recipient, subject, message, headers, and attachments.
+             * @since 4.4.0
+             */
+            do_action('wp_mail_failed', new WP_Error('wp_mail_failed', $e->getMessage(), $mail_data));
+
+            return false;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #210

The diff is quite large but when you filter out the whitespace changes it is quite simple:
```
diff --git a/includes/wp-mail-api.php b/includes/wp-mail-api.php
index 2d910a1..4cf1487 100644
--- a/includes/wp-mail-api.php
+++ b/includes/wp-mail-api.php
@@ -495,8 +495,11 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
         }

         // Email Fallback
+        if (!$isFallbackNeeded) return true;
+
         $isFallbackEnabled = get_option('email_fallback') ?: 'no';
-        if ($isFallbackNeeded && $isFallbackEnabled === 'yes') {
+        if (!($isFallbackEnabled === 'yes')) return false;
+
         global $phpmailer;

         // (Re)create it, if it's gone missing.
@@ -735,9 +738,6 @@ function wp_mail( $to, $subject, $message, $headers = '', $attachments = array()
             return false;
         }
     }
-
-        return true;
-    }
 }
```

The `if ($isFallbackNeeded && $isFallbackEnabled === 'yes') {` check is not exhaustive of all the possibilities so when a fallback is needed, but not enabled it falls through to the default return value of `true` at the bottom of the function which is incorrect. To address this I've:
1. Added a guard statement to exit early with `true` it no fallback is needed.
2. Added a guard statement to exit early with `false` if a fallback is needed but disabled.

I've also removed the fall through `return true` at the end of the function as it is now unreachable.