### PR TITLE
Fix swapped tracking labels in settings summary

### DIFF
--- a/includes/options-page.php
+++ b/includes/options-page.php
@@ -129,10 +129,10 @@ try {
                     <td>
                         <ul>
                             <li>
-                                <b>Click tracking</b> &mdash; <?php echo $settings['tracking']['open']['active'] == 1 ? 'Yes' : 'No'?>
+                                <b>Click tracking</b> &mdash; <?php echo $settings['tracking']['click']['active'] == 1 ? 'Yes' : 'No'?>
                             </li>
                             <li>
-                                <b>Open tracking</b> &mdash;  <?php echo $settings['tracking']['click']['active'] == 1 ? 'Yes' : 'No'?>
+                                <b>Open tracking</b> &mdash;  <?php echo $settings['tracking']['open']['active'] == 1 ? 'Yes' : 'No'?>
                             </li>
                             <li>
                                 <b>Unsubscribes</b> &mdash; <?php echo $settings['tracking']['unsubscribe']['active'] == 1 ? 'Yes' : 'No'?>


### PR DESCRIPTION
## Summary
- fix the domain tracking summary so click tracking reads `tracking.click.active`
- fix the domain tracking summary so open tracking reads `tracking.open.active`
- leave the per-message tracking send logic unchanged

## Notes
This fixes the account/domain summary display in the settings page. It does not change the plugin's `track-clicks` / `track-opens` send behavior.