### PR TITLE
Fix: Use domain-part as domain instead of full url

### DIFF
--- a/includes/mg-filter.php
+++ b/includes/mg-filter.php
@@ -148,6 +148,8 @@ function mg_detect_from_address( $from_addr_header = null ): string {
             $sitedomain = isset($_SERVER['SERVER_NAME']) && !empty($_SERVER['SERVER_NAME']) 
                 ? $_SERVER['SERVER_NAME'] 
                 : wp_parse_url(site_url(), PHP_URL_HOST);
+
+            $sitedomain = strtolower(sanitize_text_field($sitedomain));
             
             if (substr($sitedomain, 0, 4) === 'www.') {
                 $sitedomain = substr($sitedomain, 4);

--- a/includes/mg-filter.php
+++ b/includes/mg-filter.php
@@ -145,7 +145,10 @@ function mg_detect_from_address( $from_addr_header = null ): string {
         if (function_exists('get_current_site')) {
             $sitedomain = get_current_site()->domain;
         } else {
-            $sitedomain = strtolower(sanitize_text_field($_SERVER['SERVER_NAME'] ?? site_url()));
+            $sitedomain = isset($_SERVER['SERVER_NAME']) && !empty($_SERVER['SERVER_NAME']) 
+                ? $_SERVER['SERVER_NAME'] 
+                : wp_parse_url(site_url(), PHP_URL_HOST);
+            
             if (substr($sitedomain, 0, 4) === 'www.') {
                 $sitedomain = substr($sitedomain, 4);
             }


### PR DESCRIPTION
Use only the domain part of the home url when $_SERVER['SERVER_NAME'] is empty.

Test using 
```bash
wp eval 'echo mg_detect_from_address();'
```

Before:
wordpress@https://www.example.com

After:
wordpress@example.com