### PR TITLE
Security fix: prevent unauthenticated arbitrary list subscription (2.…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Changelog
 2.2.1 (2026-07-09)
 - Security fix: add nonce verification and server-side list address validation to the `add_list` AJAX action to prevent unauthenticated arbitrary list subscription (reported by Pedro Pinho)
 
+2.2.0 (2026-06-30)
+- Fix: use only the domain part (not the full URL) when building the Mailgun API request
+- Fix: remove automatic `key-` prefix from API key handling; stored keys that included it may need updating
+- Fix: add explicit nullable type hints for PHP 8.4 compatibility
+- Fix: correct swapped click/open tracking labels in the settings summary
+- Tested and confirmed compatible with WordPress 7.0
+
 2.1.9 (2025-06-24)
 - Added fallback option. Merge PR for widget
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+2.2.1 (2026-07-09)
+- Security fix: add nonce verification and server-side list address validation to the `add_list` AJAX action to prevent unauthenticated arbitrary list subscription (reported by Pedro Pinho)
+
 2.1.9 (2025-06-24)
 - Added fallback option. Merge PR for widget
 

--- a/mailgun.php
+++ b/mailgun.php
@@ -3,7 +3,7 @@
  * Plugin Name:  Mailgun
  * Plugin URI:   http://wordpress.org/extend/plugins/mailgun/
  * Description:  Mailgun integration for WordPress
- * Version:      2.2.0
+ * Version:      2.2.1
  * Requires PHP: 7.4
  * Requires at least: 5.6
  * Author:       Mailgun
@@ -317,11 +317,22 @@ class Mailgun {
      * @throws JsonException
      */
     public function add_list(): void {
+        if ( ! isset( $_POST['mailgun_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['mailgun_nonce'] ) ), 'mailgun_subscribe' ) ) {
+            wp_send_json( [ 'status' => 403, 'message' => 'Invalid request.' ], 403 );
+            return;
+        }
+
         $name           = sanitize_text_field( $_POST['name'] ?? null );
         $email          = sanitize_text_field( $_POST['email'] ?? null );
         $list_addresses = [];
-        foreach ( $_POST['addresses'] as $address => $val ) {
-            $list_addresses[ sanitize_text_field( $address ) ] = sanitize_text_field( $val );
+
+        $valid_lists = array_column( $this->get_lists(), 'address' );
+
+        foreach ( ( $_POST['addresses'] ?? [] ) as $address => $val ) {
+            $sanitized_address = sanitize_text_field( $address );
+            if ( in_array( $sanitized_address, $valid_lists, true ) ) {
+                $list_addresses[ $sanitized_address ] = sanitize_text_field( $val );
+            }
         }
 
         if ( ! empty( $list_addresses ) ) {
@@ -430,7 +441,8 @@ class Mailgun {
 
                 <input class="mailgun-list-submit-button" data-form-id="<?php echo esc_attr( $form_class_id ); ?>" type="button"
                         value="Subscribe"/>
-                <input type="hidden" name="mailgun-submission" value="1"/></div>
+                <input type="hidden" name="mailgun-submission" value="1"/>
+                <?php wp_nonce_field( 'mailgun_subscribe', 'mailgun_nonce' ); ?></div>
 
             </form>
             <div class="widget-list-panel result-panel" style="display:none;">

--- a/readme.md
+++ b/readme.md
@@ -136,6 +136,13 @@ MAILGUN_REPLY_TO_ADDRESS Type: string
 = 2.2.1 (2026-07-09): =
 - Security fix: add nonce verification and server-side list address validation to the `add_list` AJAX action to prevent unauthenticated arbitrary list subscription (reported by Pedro Pinho)
 
+= 2.2.0 (2026-06-30): =
+- Fix: use only the domain part (not the full URL) when building the Mailgun API request
+- Fix: remove automatic `key-` prefix from API key handling; stored keys that included it may need updating
+- Fix: add explicit nullable type hints for PHP 8.4 compatibility
+- Fix: correct swapped click/open tracking labels in the settings summary
+- Tested and confirmed compatible with WordPress 7.0
+
 = 2.1.8 (2025-05-11): =
 - Just keep update WP version. And tested compatibility with it
 

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Mailgun for WordPress
 Contributors: mailgun, sivel, lookahead.io, m35dev, alanfuller
 Tags: mailgun, smtp, http, api, mail, email
 Tested up to: 7.0
-Stable tag: 2.2.0
+Stable tag: 2.2.1
 Requires PHP: 7.4
 License: GPLv2 or later
 
@@ -132,6 +132,9 @@ MAILGUN_REPLY_TO_ADDRESS Type: string
 
 
 == Changelog ==
+
+= 2.2.1 (2026-07-09): =
+- Security fix: add nonce verification and server-side list address validation to the `add_list` AJAX action to prevent unauthenticated arbitrary list subscription (reported by Pedro Pinho)
 
 = 2.1.8 (2025-05-11): =
 - Just keep update WP version. And tested compatibility with it

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Mailgun for WordPress
 Contributors: mailgun, sivel, lookahead.io, m35dev, alanfuller
 Tags: mailgun, smtp, http, api, mail, email
 Tested up to: 7.0
-Stable tag: 2.2.0
+Stable tag: 2.2.1
 Requires PHP: 7.4
 License: GPLv2 or later
 
@@ -128,6 +128,9 @@ MAILGUN_TRACK_OPENS  Type: string Choices: 'yes' or 'no'
 6. Subscription Form Seen By Site Visitors
 
 == Changelog ==
+
+= 2.2.1 (2026-07-09): =
+- Security fix: add nonce verification and server-side list address validation to the `add_list` AJAX action to prevent unauthenticated arbitrary list subscription (reported by Pedro Pinho)
 
 = 2.1.9 (2025-06-24): =
 - Added fallback option. Merge PR for widget

--- a/readme.txt
+++ b/readme.txt
@@ -132,6 +132,13 @@ MAILGUN_TRACK_OPENS  Type: string Choices: 'yes' or 'no'
 = 2.2.1 (2026-07-09): =
 - Security fix: add nonce verification and server-side list address validation to the `add_list` AJAX action to prevent unauthenticated arbitrary list subscription (reported by Pedro Pinho)
 
+= 2.2.0 (2026-06-30): =
+- Fix: use only the domain part (not the full URL) when building the Mailgun API request
+- Fix: remove automatic `key-` prefix from API key handling; stored keys that included it may need updating
+- Fix: add explicit nullable type hints for PHP 8.4 compatibility
+- Fix: correct swapped click/open tracking labels in the settings summary
+- Tested and confirmed compatible with WordPress 7.0
+
 = 2.1.9 (2025-06-24): =
 - Added fallback option. Merge PR for widget
 


### PR DESCRIPTION
…2.1)

Add nonce verification and server-side list address allowlist validation to the add_list AJAX action. Previously the nopriv action accepted any list address and email without authentication or CSRF protection, allowing an unauthenticated attacker to enrol arbitrary addresses into the site owner's Mailgun lists using stored API credentials as a confused deputy. Reported by Pedro Pinho.