### PR TITLE
Security fix: replace insecure SHA-1/MD5 hash functions with SHA-256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+2.2.2 (2026-07-17)
+- Security fix: replace insecure SHA-1/MD5 hash functions with SHA-256 for the API request hash, multipart boundary generation, and widget ID generation
+
 2.2.1 (2026-07-09)
 - Security fix: add nonce verification and server-side list address validation to the `add_list` AJAX action to prevent unauthenticated arbitrary list subscription (reported by Pedro Pinho)
 

--- a/includes/wp-mail-api.php
+++ b/includes/wp-mail-api.php
@@ -436,7 +436,7 @@ if ( ! function_exists('wp_mail')) {
         $payload = '';
 
         // First, generate a boundary for the multipart message.
-        $boundary = sha1(uniqid('', true));
+        $boundary = hash('sha256', uniqid('', true));
 
         // Allow other plugins to apply body changes before creating the payload.
         $body = apply_filters('mg_mutate_message_body', $body);

--- a/mailgun.php
+++ b/mailgun.php
@@ -243,7 +243,7 @@ class Mailgun {
             case 'DELETE':
                 $params['sess'] = '';
                 $params['time'] = $time;
-                $params['hash'] = sha1( date( 'U' ) );
+                $params['hash'] = hash( 'sha256', date( 'U' ) );
                 break;
         }
 
@@ -522,7 +522,7 @@ class Mailgun {
      */
     public function build_list_form( array $atts ): string {
         if ( isset( $atts['id'] ) && $atts['id'] !== '' ) {
-            $args['widget_id'] = md5( rand( 10000, 99999 ) . $atts['id'] );
+            $args['widget_id'] = hash( 'sha256', rand( 10000, 99999 ) . $atts['id'] );
 
             if (isset( $atts['collect_name'] ) ) {
                 $args['collect_name'] = true;

--- a/mailgun.php
+++ b/mailgun.php
@@ -3,7 +3,7 @@
  * Plugin Name:  Mailgun
  * Plugin URI:   http://wordpress.org/extend/plugins/mailgun/
  * Description:  Mailgun integration for WordPress
- * Version:      2.2.1
+ * Version:      2.2.2
  * Requires PHP: 7.4
  * Requires at least: 5.6
  * Author:       Mailgun

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ Mailgun for WordPress
 Contributors: mailgun, sivel, lookahead.io, m35dev, alanfuller
 Tags: mailgun, smtp, http, api, mail, email
 Tested up to: 7.0
-Stable tag: 2.2.1
+Stable tag: 2.2.2
 Requires PHP: 7.4
 License: GPLv2 or later
 
@@ -132,6 +132,9 @@ MAILGUN_REPLY_TO_ADDRESS Type: string
 
 
 == Changelog ==
+
+= 2.2.2 (2026-07-17): =
+- Security fix: replace insecure SHA-1/MD5 hash functions with SHA-256 for the API request hash, multipart boundary generation, and widget ID generation
 
 = 2.2.1 (2026-07-09): =
 - Security fix: add nonce verification and server-side list address validation to the `add_list` AJAX action to prevent unauthenticated arbitrary list subscription (reported by Pedro Pinho)

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Mailgun for WordPress
 Contributors: mailgun, sivel, lookahead.io, m35dev, alanfuller
 Tags: mailgun, smtp, http, api, mail, email
 Tested up to: 7.0
-Stable tag: 2.2.1
+Stable tag: 2.2.2
 Requires PHP: 7.4
 License: GPLv2 or later
 
@@ -128,6 +128,9 @@ MAILGUN_TRACK_OPENS  Type: string Choices: 'yes' or 'no'
 6. Subscription Form Seen By Site Visitors
 
 == Changelog ==
+
+= 2.2.2 (2026-07-17): =
+- Security fix: replace insecure SHA-1/MD5 hash functions with SHA-256 for the API request hash, multipart boundary generation, and widget ID generation
 
 = 2.2.1 (2026-07-09): =
 - Security fix: add nonce verification and server-side list address validation to the `add_list` AJAX action to prevent unauthenticated arbitrary list subscription (reported by Pedro Pinho)


### PR DESCRIPTION
sha1() and md5() are cryptographically weak. Replace usages in the Mailgun API hash param, the multipart boundary generator, and the widget ID generator with hash('sha256', ...).